### PR TITLE
Support for templates and expresions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,10 @@ export function mapToRelative(currentFile, module) {
     let moduleMapped = path.relative(from, to);
 
     if(moduleMapped[0] !== '.') moduleMapped = `./${moduleMapped}`;
-    return moduleMapped;
+	
+	var sepExp = new RegExp('\\\\', 'g');
+
+    return moduleMapped.replace(sepExp, '/');
 }
 
 function mapModule(modulePath, state, filesMap) {
@@ -75,7 +78,22 @@ export default ({ types: t }) => {
                     nodePath.node.callee, [t.stringLiteral(modulePath)]
                 ));
             }
-        }
+        } else if (moduleArg && moduleArg.type === 'BinaryExpression' &&  moduleArg.left.type === 'StringLiteral') {
+		    const modulePath = mapModule(moduleArg.left.value, state, filesMap);
+		    if (modulePath) {
+			    moduleArg.left = t.stringLiteral(modulePath);
+			    nodePath.replaceWith(t.callExpression(nodePath.node.callee, [moduleArg]));
+		    }
+	    } else if (moduleArg && moduleArg.type === 'TemplateLiteral' && moduleArg.quasis.length) {
+		    const modulePath = mapModule(moduleArg.quasis[0].value.raw, state, filesMap);
+		    if (modulePath) {
+			    moduleArg.quasis[0].value = {
+				    raw: modulePath,
+				    cooked: modulePath
+			    };
+			    nodePath.replaceWith(t.callExpression(nodePath.node.callee, [moduleArg]));
+		    }
+	    }
     }
 
     function transformImportCall(nodePath, state, filesMap) {


### PR DESCRIPTION
When using dynamic paths inside require like: 
```js
require('shared/' + name)
//or
require(`shared/${name}`)
```
aliasing dosn't work. This is my propose to fix it, haven't any experience in writing babel plugins so isnt's sure is it ok.