### PR TITLE
fix: Use the a working directory based on the closed babelrc config file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,8 +6,7 @@
     }
   },
   "rules": {
-    "comma-dangle": 0,
-    "indent": [2, 4, {"SwitchCase": 1}],
+    "indent": [2, 4, { "SwitchCase": 1 }],
     "max-len": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "babel-plugin-module-resolver",
   "version": "2.2.0",
   "main": "lib/index.js",
-  "description": "Babel plugin to rewrite the path in require() and ES6 import",
+  "description": "Module resolver plugin for Babel",
   "repository": {
     "type": "git",
     "url": "https://github.com/tleunen/babel-plugin-module-resolver.git"
@@ -27,23 +27,24 @@
     "import"
   ],
   "dependencies": {
-    "glob": "^7.0.6",
+    "find-babel-config": "^1.0.1",
+    "glob": "^7.1.1",
     "resolve": "^1.1.7"
   },
   "devDependencies": {
-    "babel-cli": "^6.10.1",
-    "babel-core": "^6.10.4",
-    "babel-plugin-istanbul": "^2.0.0",
-    "babel-plugin-transform-object-rest-spread": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-register": "^6.8.0",
-    "cross-env": "^2.0.0",
-    "eslint": "^3.3.0",
-    "eslint-config-airbnb-base": "^5.0.2",
-    "eslint-plugin-import": "^1.13.0",
-    "mocha": "^3.0.2",
-    "nyc": "^8.1.0",
-    "standard-version": "^2.4.0"
+    "babel-cli": "^6.16.0",
+    "babel-core": "^6.17.0",
+    "babel-plugin-istanbul": "^2.0.1",
+    "babel-plugin-transform-object-rest-spread": "^6.16.0",
+    "babel-preset-es2015": "^6.16.0",
+    "babel-register": "^6.16.3",
+    "cross-env": "^3.1.2",
+    "eslint": "^3.7.1",
+    "eslint-config-airbnb-base": "^8.0.0",
+    "eslint-plugin-import": "^1.16.0",
+    "mocha": "^3.1.1",
+    "nyc": "^8.3.1",
+    "standard-version": "^3.0.0"
   },
   "scripts": {
     "lint": "eslint src test",

--- a/src/mapToRelative.js
+++ b/src/mapToRelative.js
@@ -1,17 +1,17 @@
 import path from 'path';
 import { toPosixPath } from './utils';
 
-function resolve(filename) {
+function resolve(cwd, filename) {
     if (path.isAbsolute(filename)) return filename;
-    return path.resolve(process.cwd(), filename);
+    return path.resolve(cwd, filename);
 }
 
-export default function mapToRelative(currentFile, module) {
+export default function mapToRelative(cwd, currentFile, module) {
     let from = path.dirname(currentFile);
     let to = path.normalize(module);
 
-    from = resolve(from);
-    to = resolve(to);
+    from = resolve(cwd, from);
+    to = resolve(cwd, to);
 
     const moduleMapped = path.relative(from, to);
     return toPosixPath(moduleMapped);

--- a/test/index.js
+++ b/test/index.js
@@ -27,18 +27,18 @@ describe('module-resolver', () => {
                 [plugin, {
                     root: [
                         './test/examples/components',
-                        './test/examples/foo'
-                    ]
-                }]
-            ]
+                        './test/examples/foo',
+                    ],
+                }],
+            ],
         };
 
         const transformerOptsGlob = {
             plugins: [
                 [plugin, {
-                    root: ['./test/**/components']
-                }]
-            ]
+                    root: ['./test/**/components'],
+                }],
+            ],
         };
 
         describe('should resolve the file path', () => {
@@ -89,7 +89,7 @@ describe('module-resolver', () => {
                 '../bar',
                 {
                     ...transformerOpts,
-                    filename: './test/examples/foo/bar/x.js'
+                    filename: './test/examples/foo/bar/x.js',
                 }
             );
         });
@@ -111,10 +111,10 @@ describe('module-resolver', () => {
                         utils: './src/mylib/subfolder/utils',
                         'awesome/components': './src/components',
                         abstract: 'npm:concrete',
-                        underscore: 'lodash'
-                    }
-                }]
-            ]
+                        underscore: 'lodash',
+                    },
+                }],
+            ],
         };
 
         describe('with a simple alias', () => {

--- a/test/mapToRelative.js
+++ b/test/mapToRelative.js
@@ -4,27 +4,17 @@ import assert from 'assert';
 import mapToRelative from '../src/mapToRelative';
 
 describe('mapToRelative', () => {
-    describe('should map to relative path when cwd has been changed', () => {
-        const cwd = process.cwd();
-
-        before(() => {
-            process.chdir('./test');
-        });
-
-        after(() => {
-            process.chdir(cwd);
-        });
-
+    describe('should map to relative path with a custom cwd', () => {
         it('with relative filename', () => {
             const currentFile = './utils/test/file.js';
-            const result = mapToRelative(currentFile, 'utils/dep');
+            const result = mapToRelative(path.resolve('./test'), currentFile, 'utils/dep');
 
             assert.strictEqual(result, '../dep');
         });
 
         it('with absolute filename', () => {
             const currentFile = path.join(process.cwd(), './utils/test/file.js');
-            const result = mapToRelative(currentFile, 'utils/dep');
+            const result = mapToRelative(process.cwd(), currentFile, 'utils/dep');
 
             assert.strictEqual(result, '../dep');
         });


### PR DESCRIPTION
Fixes #61 

Hey @danez and @valerybugakov, can I ask you to try this fix and let me know if this resolves your issues? :)

For every file, I now get the closest babel config file to calculate the relative paths based on it instead of the working directory (which could be different).