### PR TITLE
Fix root mapping with custom extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ import MyUtilFn from '../../../../utils/MyUtilFn';
 // Use that:
 import MyUtilFn from 'utils/MyUtilFn';
 ```
-
-_Note:_ It also work for `require()`.
-
-_Note 2:_ You can use the `npm:` prefix in your plugin configuration to map a node module.
-
+_Note:_ It also works with `require()`, and you can alias a NPM module.
 
 ## Usage
 
@@ -27,7 +23,6 @@ Install the plugin
 ```
 $ npm install --save-dev babel-plugin-module-resolver
 ```
-
 
 Specify the plugin in your `.babelrc` with the custom root or alias. Here's an example:
 ```json
@@ -43,6 +38,7 @@ Specify the plugin in your `.babelrc` with the custom root or alias. Here's an e
     ]
 }
 ```
+_Note:_ If you're using a custom extension (other than .js, .jsx, .es and .es6), you can add the `extensions` array in the config.
 
 ## ESLint plugin
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "require",
     "import"
   ],
+  "dependencies": {
+    "resolve": "^1.1.7"
+  },
   "devDependencies": {
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ function testRequireImport(source, output, transformerOpts) {
     });
 }
 
-describe('modulesDirectories', () => {
+describe('root', () => {
     const transformerOpts = {
         plugins: [
             [plugin, {
@@ -40,6 +40,14 @@ describe('modulesDirectories', () => {
         testRequireImport(
             'sub/sub1',
             './test/examples/components/sub/sub1',
+            transformerOpts
+        );
+    });
+
+    describe('should rewrite the file while keeping the extension', () => {
+        testRequireImport(
+            'sub/sub1.css',
+            './test/examples/components/sub/sub1.css',
             transformerOpts
         );
     });
@@ -102,6 +110,14 @@ describe('alias', () => {
                 );
             });
         });
+    });
+
+    describe('should alias the path with its extension', () => {
+        testRequireImport(
+            'awesome/components/my-comp.css',
+            './src/components/my-comp.css',
+            transformerOpts
+        );
     });
 
     describe('should not alias a unknown path', () => {


### PR DESCRIPTION
Fixes #70 
cc @kellyrmilligan

This should resolve your issue :)
These extensions `['.js', '.jsx', '.es', '.es6']` will be handled by default, because these are the ones Babel handle. But I also added a new setting to set any custom extension.