### PR TITLE
feat: Aliasing a npm module without 'npm:'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Specify the plugin in your `.babelrc` with the custom root or alias. Here's an e
       ["module-resolver", {
         "root": ["./src"],
         "alias": {
-          "test": "./test"
+          "test": "./test",
+          "underscore": "lodash"
         }
       }]
     ]

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,15 @@ export function mapModule(source, file, pluginOpts) {
         return null;
     }
 
+    // remove legacy "npm:" prefix for npm packages
+    aliasPath = aliasPath.replace(/^(npm:)/, '');
     const newPath = source.replace(moduleSplit.join('/'), aliasPath);
+
+    // alias to npm module don't need relative mapping
+    if (aliasPath[0] !== '.') {
+        return newPath;
+    }
+    // relative alias
     return mapToRelative(file, newPath);
 }
 

--- a/src/mapToRelative.js
+++ b/src/mapToRelative.js
@@ -20,12 +20,6 @@ export default function mapToRelative(currentFile, module) {
 
     moduleMapped = toPosixPath(moduleMapped);
 
-    // Support npm modules instead of directories
-    if (moduleMapped.indexOf('npm:') !== -1) {
-        const [, npmModuleName] = moduleMapped.split('npm:');
-        return npmModuleName;
-    }
-
     if (moduleMapped[0] !== '.') moduleMapped = `./${moduleMapped}`;
 
     return moduleMapped;

--- a/test/index.js
+++ b/test/index.js
@@ -68,7 +68,8 @@ describe('alias', () => {
                 alias: {
                     utils: './src/mylib/subfolder/utils',
                     'awesome/components': './src/components',
-                    abstract: 'npm:concrete'
+                    abstract: 'npm:concrete',
+                    underscore: 'lodash'
                 }
             }]
         ]
@@ -138,10 +139,18 @@ describe('alias', () => {
         });
     });
 
-    describe('should support remapping to node modules with "npm:"', () => {
+    describe('(legacy) should support aliasing a node module with "npm:"', () => {
         testRequireImport(
             'abstract/thing',
             'concrete/thing',
+            transformerOpts
+        );
+    });
+
+    describe('should support aliasing a node modules', () => {
+        testRequireImport(
+            'underscore/map',
+            'lodash/map',
             transformerOpts
         );
     });


### PR DESCRIPTION
The `npm:` prefix wasn't really necessary because we can detect if the final path is a local file (starting with a dot), or a path to a npm module.

The following example will redirect all underscore calls to lodash.
```json
{
  "alias": {
    "underscore": "lodash"
  }
}
```