### PR TITLE
fix: Fix resolver with filename containing a dot

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,11 @@ export function mapModule(source, file, pluginOpts) {
             // check if the file exists (will throw if not)
             const extensions = pluginOpts.extensions || defaultBabelExtensions;
             const fileAbsPath = resolve.sync(`./${source}`, { basedir: path.resolve(rootDirs[i]), extensions });
+            const realFileExt = path.extname(fileAbsPath);
+            const sourceFileExt = path.extname(source);
             // map the source and keep its extension if the import/require had one
-            return mapToRelative(file, replaceExt(fileAbsPath, path.extname(source)));
+            const ext = realFileExt === sourceFileExt ? realFileExt : '';
+            return mapToRelative(file, replaceExt(fileAbsPath, ext));
         } catch (e) {
             // empty...
         }

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,14 @@ describe('root', () => {
         );
     });
 
+    describe('should rewrite the file with a filename containing a dot', () => {
+        testRequireImport(
+            'sub/custom.modernizr3',
+            './test/examples/components/sub/custom.modernizr3',
+            transformerOpts
+        );
+    });
+
     describe('should not rewrite a path outisde of the root directory', () => {
         testRequireImport(
             'example-file',
@@ -110,6 +118,14 @@ describe('alias', () => {
                     transformerOpts
                 );
             });
+        });
+
+        describe('with a dot in the filename', () => {
+            testRequireImport(
+                'utils/custom.modernizr3',
+                './src/mylib/subfolder/utils/custom.modernizr3',
+                transformerOpts
+            );
         });
     });
 


### PR DESCRIPTION
Fixes #74 

Checking the extension of the source file and the real file allows us to verify it's a real extension of something from the filename.