### PR TITLE
Fix root globbing cwd in Sublime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,13 +23,16 @@ function isRegExp(string) {
   return string.startsWith('^') || string.endsWith('$');
 }
 
-export function manipulatePluginOptions(pluginOpts) {
+// The working directory of Atom is the project,
+// while Sublime sets the working project to the directory in which the current opened file is
+// So we need to offer a way to customize the cwd for the eslint plugin
+export function manipulatePluginOptions(pluginOpts, cwd = process.cwd()) {
   if (pluginOpts.root) {
     // eslint-disable-next-line no-param-reassign
     pluginOpts.root = pluginOpts.root.reduce((resolvedDirs, dirPath) => {
       if (glob.hasMagic(dirPath)) {
         return resolvedDirs.concat(
-          glob.sync(dirPath).filter(p => fs.lstatSync(p).isDirectory()),
+          glob.sync(dirPath, { cwd }).filter(p => fs.lstatSync(p).isDirectory()),
         );
       }
       return resolvedDirs.concat(dirPath);


### PR DESCRIPTION
Required to be able to fix this issue in the eslint plugin: https://github.com/tleunen/eslint-import-resolver-babel-module/issues/42

It also means there's potentially another issue here, since we need to know the cwd to compute the root paths, but we can determine the real cwd only once we start parsing a file. So the used cwd in `manipulateOptions` might not always be the right one. (eg project root instead of being the babelrc root, which might be a subdirectory of the project root)

@fatfisz Any idea?

In the short term, it should fix the initial issue with sublime, but it'll be great to find a solution to this cwd