### PR TITLE
fix: Fix `regExps.find` undefined error

### DIFF
--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -98,7 +98,7 @@ export default function getRealPath(sourcePath, currentFile, opts) {
 
   const { cwd, extensions, pluginOpts } = opts;
   const rootDirs = pluginOpts.root || [];
-  const regExps = pluginOpts.regExps;
+  const regExps = pluginOpts.regExps || [];
   const alias = pluginOpts.alias || {};
 
   const sourceFileFromRoot = getRealPathFromRootConfig(


### PR DESCRIPTION
This quickfix should resolve the `Cannot read property 'find' of undefined` error a few users have.

I'll need to investigate further to better understand why in some cases, `regExps` is not set.