### PR TITLE
Fix the double plugin bug

### DIFF
--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -98,7 +98,7 @@ export default function getRealPath(sourcePath, currentFile, opts) {
 
   const { cwd, extensions, pluginOpts } = opts;
   const rootDirs = pluginOpts.root || [];
-  const regExps = pluginOpts.regExps || [];
+  const regExps = pluginOpts.regExps;
   const alias = pluginOpts.alias || {};
 
   const sourceFileFromRoot = getRealPathFromRootConfig(

--- a/src/index.js
+++ b/src/index.js
@@ -82,15 +82,11 @@ export default ({ types: t }) => {
   };
 
   return {
-    manipulateOptions(babelOptions) {
-      let findPluginOptions = babelOptions.plugins.find(plugin => plugin[0] === this)[1];
-      findPluginOptions = manipulatePluginOptions(findPluginOptions);
-
-      this.customCWD = findPluginOptions.cwd;
-    },
-
     pre(file) {
-      let { customCWD } = this.plugin;
+      manipulatePluginOptions(this.opts);
+
+      let customCWD = this.opts.cwd;
+
       if (customCWD === 'babelrc') {
         const startPath = (file.opts.filename === 'unknown')
           ? './'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -435,6 +435,27 @@ describe('module-resolver', () => {
         );
       });
     });
+
+    describe('with the plugin applied twice', () => {
+      const doubleAliasTransformerOpts = {
+        plugins: [
+          plugin,
+          [plugin, {
+            alias: {
+              '^@namespace/foo-(.+)': 'packages/\\1',
+            },
+          }],
+        ],
+      };
+
+      describe('should support replacing parts of a path', () => {
+        testRequireImport(
+          '@namespace/foo-bar',
+          'packages/bar',
+          doubleAliasTransformerOpts,
+        );
+      });
+    });
   });
 
   describe('with custom cwd', () => {


### PR DESCRIPTION
This reverts the change in 217120065e5dbe13f6671c8bca4212cf42fe5279, because it si not covered by any tests. If `getRealPath` should handle unparsed options, then I'd at least like to add some tests.