### PR TITLE
Refactor options preprocessing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,4 +5,7 @@ module.exports = {
   extends: [
     'airbnb-base',
   ],
+  rules: {
+    'no-param-reassign': [2, { props: false }],
+  },
 };

--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -89,7 +89,7 @@ function getRealPathFromRegExpConfig(sourcePath, regExps) {
   return aliasedSourceFile;
 }
 
-export default function getRealPath(sourcePath, { cwd, file, opts }) {
+export default function getRealPath(sourcePath, { file, opts }) {
   if (sourcePath[0] === '.') {
     return sourcePath;
   }
@@ -99,7 +99,7 @@ export default function getRealPath(sourcePath, { cwd, file, opts }) {
   const currentFile = file.opts.filename;
   const absCurrentFile = path.resolve(currentFile);
 
-  const { root, extensions, alias, regExps } = opts;
+  const { cwd, root, extensions, alias, regExps } = opts;
 
   const sourceFileFromRoot = getRealPathFromRootConfig(
     sourcePath, absCurrentFile, root, cwd, extensions,

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ function normalizeCwd(file) {
   }
 }
 
-function normalizePluginOptions(file) {
+function normalizeOptions(file) {
   const { opts } = this;
 
   normalizeCwd.call(this, file);
@@ -100,7 +100,7 @@ export default ({ types }) => {
   };
 
   return {
-    pre: normalizePluginOptions,
+    pre: normalizeOptions,
 
     visitor: {
       Program: {

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,8 @@ function isRegExp(string) {
 export function manipulatePluginOptions(pluginOpts, cwd = process.cwd()) {
   if (pluginOpts.root) {
     if (typeof pluginOpts.root === 'string') {
-      pluginOpts.root = [pluginOpts.root]; // eslint-disable-line no-param-reassign
+      pluginOpts.root = [pluginOpts.root];
     }
-    // eslint-disable-next-line no-param-reassign
     pluginOpts.root = pluginOpts.root.reduce((resolvedDirs, dirPath) => {
       if (glob.hasMagic(dirPath)) {
         return resolvedDirs.concat(
@@ -32,11 +31,9 @@ export function manipulatePluginOptions(pluginOpts, cwd = process.cwd()) {
       return resolvedDirs.concat(dirPath);
     }, []);
   } else {
-    // eslint-disable-next-line no-param-reassign
     pluginOpts.root = [];
   }
 
-  // eslint-disable-next-line no-param-reassign
   pluginOpts.regExps = [];
 
   if (pluginOpts.alias) {
@@ -55,16 +52,13 @@ export function manipulatePluginOptions(pluginOpts, cwd = process.cwd()) {
 
         pluginOpts.regExps.push([new RegExp(key), substitute]);
 
-        // eslint-disable-next-line no-param-reassign
         delete pluginOpts.alias[key];
       });
   } else {
-    // eslint-disable-next-line no-param-reassign
     pluginOpts.alias = {};
   }
 
   if (!pluginOpts.extensions) {
-    // eslint-disable-next-line no-param-reassign
     pluginOpts.extensions = defaultExtensions;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,40 +7,61 @@ import transformCall from './transformers/call';
 import transformImport from './transformers/import';
 
 
-const defaultBabelExtensions = ['.js', '.jsx', '.es', '.es6'];
-export const defaultExtensions = defaultBabelExtensions;
+const defaultExtensions = ['.js', '.jsx', '.es', '.es6'];
 
 function isRegExp(string) {
   return string.startsWith('^') || string.endsWith('$');
 }
 
-// The working directory of Atom is the project,
-// while Sublime sets the working project to the directory in which the current opened file is
-// So we need to offer a way to customize the cwd for the eslint plugin
-export function manipulatePluginOptions(pluginOpts, cwd = process.cwd()) {
-  if (pluginOpts.root) {
-    if (typeof pluginOpts.root === 'string') {
-      pluginOpts.root = [pluginOpts.root];
+function normalizeCwd(file) {
+  const { opts } = this;
+
+  if (opts.cwd === 'babelrc') {
+    const startPath = (file.opts.filename === 'unknown')
+      ? './'
+      : file.opts.filename;
+
+    const { file: babelPath } = findBabelConfig.sync(startPath);
+
+    opts.cwd = babelPath
+      ? path.dirname(babelPath)
+      : null;
+  }
+
+  if (!opts.cwd) {
+    opts.cwd = process.cwd();
+  }
+}
+
+function normalizePluginOptions(file) {
+  const { opts } = this;
+
+  normalizeCwd.call(this, file);
+
+  if (opts.root) {
+    if (typeof opts.root === 'string') {
+      opts.root = [opts.root];
     }
-    pluginOpts.root = pluginOpts.root.reduce((resolvedDirs, dirPath) => {
+    opts.root = opts.root.reduce((resolvedDirs, dirPath) => {
       if (glob.hasMagic(dirPath)) {
         return resolvedDirs.concat(
-          glob.sync(dirPath, { cwd }).filter(p => fs.lstatSync(p).isDirectory()),
+          glob.sync(dirPath)
+            .filter(resolvedPath => fs.lstatSync(resolvedPath).isDirectory()),
         );
       }
       return resolvedDirs.concat(dirPath);
     }, []);
   } else {
-    pluginOpts.root = [];
+    opts.root = [];
   }
 
-  pluginOpts.regExps = [];
+  opts.regExps = [];
 
-  if (pluginOpts.alias) {
-    Object.keys(pluginOpts.alias)
+  if (opts.alias) {
+    Object.keys(opts.alias)
       .filter(isRegExp)
       .forEach((key) => {
-        const parts = pluginOpts.alias[key].split('\\\\');
+        const parts = opts.alias[key].split('\\\\');
 
         function substitute(execResult) {
           return parts
@@ -50,19 +71,19 @@ export function manipulatePluginOptions(pluginOpts, cwd = process.cwd()) {
             .join('\\');
         }
 
-        pluginOpts.regExps.push([new RegExp(key), substitute]);
+        opts.regExps.push([new RegExp(key), substitute]);
 
-        delete pluginOpts.alias[key];
+        delete opts.alias[key];
       });
   } else {
-    pluginOpts.alias = {};
+    opts.alias = {};
   }
 
-  if (!pluginOpts.extensions) {
-    pluginOpts.extensions = defaultExtensions;
+  if (!opts.extensions) {
+    opts.extensions = defaultExtensions;
   }
 
-  return pluginOpts;
+  return opts;
 }
 
 export default ({ types }) => {
@@ -79,24 +100,7 @@ export default ({ types }) => {
   };
 
   return {
-    pre(file) {
-      manipulatePluginOptions(this.opts);
-
-      let customCWD = this.opts.cwd;
-
-      if (customCWD === 'babelrc') {
-        const startPath = (file.opts.filename === 'unknown')
-          ? './'
-          : file.opts.filename;
-
-        const { file: babelFile } = findBabelConfig.sync(startPath);
-        customCWD = babelFile
-          ? path.dirname(babelFile)
-          : null;
-      }
-
-      this.cwd = customCWD || process.cwd();
-    },
+    pre: normalizePluginOptions,
 
     visitor: {
       Program: {


### PR DESCRIPTION
Those are some additional changes for the bug fix that I had in my repo. Mostly refactoring, no behavior changed (tests are intact).

Notable change: the `no-param-reassign` rule was disabled inline so many times that it made sense to allow it in the configuration - only for property assignment, not arguments themselves (they are like `const` values now).