### PR TITLE
Resolve aliases before root paths

### DIFF
--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -101,13 +101,6 @@ export default function getRealPath(sourcePath, currentFile, opts) {
   const regExps = pluginOpts.regExps;
   const alias = pluginOpts.alias || {};
 
-  const sourceFileFromRoot = getRealPathFromRootConfig(
-    sourcePath, absCurrentFile, rootDirs, cwd, extensions,
-  );
-  if (sourceFileFromRoot) {
-    return sourceFileFromRoot;
-  }
-
   const sourceFileFromAlias = getRealPathFromAliasConfig(
     sourcePath, absCurrentFile, alias, cwd,
   );
@@ -120,6 +113,13 @@ export default function getRealPath(sourcePath, currentFile, opts) {
   );
   if (sourceFileFromRegExp) {
     return sourceFileFromRegExp;
+  }
+
+  const sourceFileFromRoot = getRealPathFromRootConfig(
+    sourcePath, absCurrentFile, rootDirs, cwd, extensions,
+  );
+  if (sourceFileFromRoot) {
+    return sourceFileFromRoot;
   }
 
   return sourcePath;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -110,6 +110,9 @@ describe('module-resolver', () => {
         plugins: [
           [plugin, {
             root: './test/testproject/src',
+            alias: {
+              'constants/actions': './test/testproject/test/mockApp',
+            },
           }],
         ],
       };
@@ -208,6 +211,14 @@ describe('module-resolver', () => {
         testRequireImport(
           './something',
           './something',
+          rootTransformerOpts,
+        );
+      });
+
+      describe('should alias before resolving to an existing path', () => {
+        testRequireImport(
+          'constants/actions',
+          './test/testproject/test/mockApp',
           rootTransformerOpts,
         );
       });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -196,7 +196,7 @@ describe('module-resolver', () => {
         );
       });
 
-      describe('should not resolve a path outisde of the root directory', () => {
+      describe('should not resolve a path outside of the root directory', () => {
         testRequireImport(
           'lodash/omit',
           'lodash/omit',


### PR DESCRIPTION
I encountered an issue while trying to mock an existing file, noticed that the `getRealPathFromRootConfig` is done before  `getRealPathFromAliasConfig` which prevented my aliases from working. This PR simply re-order the resolutions of paths and add a test.

I added a `mockApp.js` file for the sake of the example I guess 🤷🏽‍♂️, don't think it's needed.

Also, fixes two small typos 😬