### PR TITLE
Fix: use the cwd option for glob patterns

### DIFF
--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -5,14 +5,14 @@ import mapToRelative from './mapToRelative';
 import { toLocalPath, toPosixPath, replaceExtension } from './utils';
 
 
-function findPathInRoots(sourcePath, rootDirs, cwd, extensions) {
+function findPathInRoots(sourcePath, rootDirs, extensions) {
   // Search the source path inside every custom root directory
   let resolvedSourceFile;
-  rootDirs.some((dir) => {
+  rootDirs.some((basedir) => {
     try {
       // check if the file exists (will throw if not)
       resolvedSourceFile = resolve.sync(`./${sourcePath}`, {
-        basedir: path.resolve(cwd, dir),
+        basedir,
         extensions,
       });
       return true;
@@ -25,21 +25,21 @@ function findPathInRoots(sourcePath, rootDirs, cwd, extensions) {
 }
 
 function getRealPathFromRootConfig(sourcePath, absCurrentFile, rootDirs, cwd, extensions) {
-  const absFileInRoot = findPathInRoots(sourcePath, rootDirs, cwd, extensions);
+  const absFileInRoot = findPathInRoots(sourcePath, rootDirs, extensions);
 
-  if (absFileInRoot) {
-    const realSourceFileExtension = path.extname(absFileInRoot);
-    const sourceFileExtension = path.extname(sourcePath);
-
-    // map the source and keep its extension if the import/require had one
-    const ext = realSourceFileExtension === sourceFileExtension ? realSourceFileExtension : '';
-    return toLocalPath(toPosixPath(replaceExtension(
-      mapToRelative(cwd, absCurrentFile, absFileInRoot),
-      ext,
-    )));
+  if (!absFileInRoot) {
+    return null;
   }
 
-  return null;
+  const realSourceFileExtension = path.extname(absFileInRoot);
+  const sourceFileExtension = path.extname(sourcePath);
+
+  // map the source and keep its extension if the import/require had one
+  const ext = realSourceFileExtension === sourceFileExtension ? realSourceFileExtension : '';
+  return toLocalPath(toPosixPath(replaceExtension(
+    mapToRelative(cwd, absCurrentFile, absFileInRoot),
+    ext,
+  )));
 }
 
 function getRealPathFromAliasConfig(sourcePath, absCurrentFile, alias, cwd) {

--- a/src/index.js
+++ b/src/index.js
@@ -42,15 +42,18 @@ function normalizeOptions(file) {
     if (typeof opts.root === 'string') {
       opts.root = [opts.root];
     }
-    opts.root = opts.root.reduce((resolvedDirs, dirPath) => {
-      if (glob.hasMagic(dirPath)) {
-        return resolvedDirs.concat(
-          glob.sync(dirPath)
-            .filter(resolvedPath => fs.lstatSync(resolvedPath).isDirectory()),
-        );
-      }
-      return resolvedDirs.concat(dirPath);
-    }, []);
+    opts.root = opts.root
+      .map(dirPath => path.resolve(opts.cwd, dirPath))
+      .reduce((resolvedDirs, absDirPath) => {
+        if (glob.hasMagic(absDirPath)) {
+          const roots = glob.sync(absDirPath)
+            .filter(resolvedPath => fs.lstatSync(resolvedPath).isDirectory());
+
+          return [...resolvedDirs, ...roots];
+        }
+
+        return [...resolvedDirs, absDirPath];
+      }, []);
   } else {
     opts.root = [];
   }

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function normalizeOptions(file) {
   normalizeCwd.call(this, file);
 
   if (opts.root) {
-    if (typeof opts.root === 'string') {
+    if (!Array.isArray(opts.root)) {
       opts.root = [opts.root];
     }
     opts.root = opts.root

--- a/src/mapToRelative.js
+++ b/src/mapToRelative.js
@@ -3,20 +3,12 @@ import path from 'path';
 import { toPosixPath } from './utils';
 
 
-function resolve(cwd, filename) {
-  if (path.isAbsolute(filename)) {
-    return filename;
-  }
-
-  return path.resolve(cwd, filename);
-}
-
 export default function mapToRelative(cwd, currentFile, module) {
   let from = path.dirname(currentFile);
   let to = path.normalize(module);
 
-  from = resolve(cwd, from);
-  to = resolve(cwd, to);
+  from = path.resolve(cwd, from);
+  to = path.resolve(cwd, to);
 
   const moduleMapped = path.relative(from, to);
   return toPosixPath(moduleMapped);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -464,7 +464,7 @@ describe('module-resolver', () => {
         babelrc: false,
         plugins: [
           [plugin, {
-            root: ['./testproject/*'],
+            root: './testproject/*',
             cwd: path.resolve('test'),
           }],
         ],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -415,6 +415,9 @@ describe('module-resolver', () => {
           [plugin, {
             root: './testproject/src',
             cwd: path.resolve('test'),
+            alias: {
+              test: './testproject/test',
+            },
           }],
         ],
       };
@@ -423,6 +426,14 @@ describe('module-resolver', () => {
         testWithImport(
           'components/Root',
           './test/testproject/src/components/Root',
+          transformerOpts,
+        );
+      });
+
+      it('should alias the sub file path', () => {
+        testWithImport(
+          'test/tools',
+          './test/testproject/test/tools',
           transformerOpts,
         );
       });
@@ -435,6 +446,26 @@ describe('module-resolver', () => {
           [plugin, {
             root: './src',
             cwd: path.resolve('test/testproject'),
+          }],
+        ],
+      };
+
+      it('should resolve the sub file path', () => {
+        testWithImport(
+          'components/Root',
+          './test/testproject/src/components/Root',
+          transformerOpts,
+        );
+      });
+    });
+
+    describe('with glob root', () => {
+      const transformerOpts = {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            root: ['./testproject/*'],
+            cwd: path.resolve('test'),
           }],
         ],
       };


### PR DESCRIPTION
This is actually a bugfix - the cwd was being used too late, after resolving the glob pattern. If it is done before, the glob package will look for resolved paths in the right directory from the start.