### PR TITLE
Chore: specify more loose options for babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,13 @@
 {
-  "presets": ["env"],
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": 4
+      },
+      "loose": true,
+      "useBuiltIns": true
+    }]
+  ],
   "plugins": [
     "transform-object-rest-spread"
   ]


### PR DESCRIPTION
Rollup is great: it reduces the number of `require` calls and produces a clean output, while putting all of the modules in the same scope.

I've also set the "loose" option for babel plugins for a cleaner output.