### PR TITLE
Chore: refactor normalizeOptions and the resolver pipeline

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,31 +3,24 @@ import transformCall from './transformers/call';
 import transformImport from './transformers/import';
 
 
-export default ({ types }) => {
-  const importVisitors = {
-    CallExpression(nodePath, state) {
-      transformCall(nodePath, state);
-    },
-    ImportDeclaration(nodePath, state) {
-      transformImport(nodePath, state);
-    },
-    ExportDeclaration(nodePath, state) {
-      transformImport(nodePath, state);
-    },
-  };
-
-  return {
-    pre(file) {
-      this.types = types;
-      normalizeOptions(this.opts, file);
-    },
-
-    visitor: {
-      Program: {
-        exit(programPath, state) {
-          programPath.traverse(importVisitors, state);
-        },
-      },
-    },
-  };
+const importVisitors = {
+  CallExpression: transformCall,
+  'ImportDeclaration|ExportDeclaration': transformImport,
 };
+
+const visitor = {
+  Program: {
+    exit(programPath, state) {
+      programPath.traverse(importVisitors, state);
+    },
+  },
+};
+
+export default ({ types }) => ({
+  pre(file) {
+    this.types = types;
+    normalizeOptions(this.opts, file);
+  },
+
+  visitor,
+});

--- a/src/index.js
+++ b/src/index.js
@@ -6,18 +6,19 @@ import transformImport from './transformers/import';
 export default ({ types }) => {
   const importVisitors = {
     CallExpression(nodePath, state) {
-      transformCall(types, nodePath, state);
+      transformCall(nodePath, state);
     },
     ImportDeclaration(nodePath, state) {
-      transformImport(types, nodePath, state);
+      transformImport(nodePath, state);
     },
     ExportDeclaration(nodePath, state) {
-      transformImport(types, nodePath, state);
+      transformImport(nodePath, state);
     },
   };
 
   return {
     pre(file) {
+      this.types = types;
       normalizeOptions(this.opts, file);
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,93 +1,7 @@
-import fs from 'fs';
-import path from 'path';
-
-import findBabelConfig from 'find-babel-config';
-import glob from 'glob';
+import normalizeOptions from './normalizeOptions';
 import transformCall from './transformers/call';
 import transformImport from './transformers/import';
 
-
-const defaultExtensions = ['.js', '.jsx', '.es', '.es6'];
-
-function isRegExp(string) {
-  return string.startsWith('^') || string.endsWith('$');
-}
-
-function normalizeCwd(file) {
-  const { opts } = this;
-
-  if (opts.cwd === 'babelrc') {
-    const startPath = (file.opts.filename === 'unknown')
-      ? './'
-      : file.opts.filename;
-
-    const { file: babelPath } = findBabelConfig.sync(startPath);
-
-    opts.cwd = babelPath
-      ? path.dirname(babelPath)
-      : null;
-  }
-
-  if (!opts.cwd) {
-    opts.cwd = process.cwd();
-  }
-}
-
-function normalizeOptions(file) {
-  const { opts } = this;
-
-  normalizeCwd.call(this, file);
-
-  if (opts.root) {
-    if (!Array.isArray(opts.root)) {
-      opts.root = [opts.root];
-    }
-    opts.root = opts.root
-      .map(dirPath => path.resolve(opts.cwd, dirPath))
-      .reduce((resolvedDirs, absDirPath) => {
-        if (glob.hasMagic(absDirPath)) {
-          const roots = glob.sync(absDirPath)
-            .filter(resolvedPath => fs.lstatSync(resolvedPath).isDirectory());
-
-          return [...resolvedDirs, ...roots];
-        }
-
-        return [...resolvedDirs, absDirPath];
-      }, []);
-  } else {
-    opts.root = [];
-  }
-
-  opts.regExps = [];
-
-  if (opts.alias) {
-    Object.keys(opts.alias)
-      .filter(isRegExp)
-      .forEach((key) => {
-        const parts = opts.alias[key].split('\\\\');
-
-        function substitute(execResult) {
-          return parts
-            .map(part =>
-              part.replace(/\\\d+/g, number => execResult[number.slice(1)] || ''),
-            )
-            .join('\\');
-        }
-
-        opts.regExps.push([new RegExp(key), substitute]);
-
-        delete opts.alias[key];
-      });
-  } else {
-    opts.alias = {};
-  }
-
-  if (!opts.extensions) {
-    opts.extensions = defaultExtensions;
-  }
-
-  return opts;
-}
 
 export default ({ types }) => {
   const importVisitors = {
@@ -103,7 +17,9 @@ export default ({ types }) => {
   };
 
   return {
-    pre: normalizeOptions,
+    pre(file) {
+      normalizeOptions(this.opts, file);
+    },
 
     visitor: {
       Program: {

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import path from 'path';
+
+import findBabelConfig from 'find-babel-config';
+import glob from 'glob';
+
+
+const defaultExtensions = ['.js', '.jsx', '.es', '.es6'];
+
+function isRegExp(string) {
+  return string.startsWith('^') || string.endsWith('$');
+}
+
+function normalizeCwd(opts, file) {
+  if (opts.cwd === 'babelrc') {
+    const startPath = (file.opts.filename === 'unknown')
+      ? './'
+      : file.opts.filename;
+
+    const { file: babelPath } = findBabelConfig.sync(startPath);
+
+    opts.cwd = babelPath
+      ? path.dirname(babelPath)
+      : null;
+  }
+
+  if (!opts.cwd) {
+    opts.cwd = process.cwd();
+  }
+}
+
+function normalizeRoot(opts) {
+  if (opts.root) {
+    if (!Array.isArray(opts.root)) {
+      opts.root = [opts.root];
+    }
+    opts.root = opts.root
+      .map(dirPath => path.resolve(opts.cwd, dirPath))
+      .reduce((resolvedDirs, absDirPath) => {
+        if (glob.hasMagic(absDirPath)) {
+          const roots = glob.sync(absDirPath)
+            .filter(resolvedPath => fs.lstatSync(resolvedPath).isDirectory());
+
+          return [...resolvedDirs, ...roots];
+        }
+
+        return [...resolvedDirs, absDirPath];
+      }, []);
+  } else {
+    opts.root = [];
+  }
+}
+
+function normalizeAlias(opts) {
+  opts.regExps = [];
+
+  if (opts.alias) {
+    Object.keys(opts.alias)
+      .filter(isRegExp)
+      .forEach((key) => {
+        const parts = opts.alias[key].split('\\\\');
+
+        function substitute(execResult) {
+          return parts
+            .map(part =>
+              part.replace(/\\\d+/g, number => execResult[number.slice(1)] || ''),
+            )
+            .join('\\');
+        }
+
+        opts.regExps.push([new RegExp(key), substitute]);
+
+        delete opts.alias[key];
+      });
+  } else {
+    opts.alias = {};
+  }
+}
+
+export default function normalizeOptions(opts, file) {
+  normalizeCwd(opts, file); // This has to go first because other options rely on cwd
+  normalizeRoot(opts);
+  normalizeAlias(opts);
+
+  if (!opts.extensions) {
+    opts.extensions = defaultExtensions;
+  }
+}

--- a/src/transformers/call.js
+++ b/src/transformers/call.js
@@ -12,10 +12,10 @@ const patterns = [
   'jest.dontMock',
 ];
 
-export default function transformCall(types, nodePath, state) {
+export default function transformCall(nodePath, state) {
   const calleePath = nodePath.get('callee');
 
-  if (patterns.some(pattern => matchesPattern(types, calleePath, pattern))) {
-    mapPathString(types, nodePath.get('arguments.0'), state);
+  if (patterns.some(pattern => matchesPattern(state.types, calleePath, pattern))) {
+    mapPathString(nodePath.get('arguments.0'), state);
   }
 }

--- a/src/transformers/import.js
+++ b/src/transformers/import.js
@@ -1,6 +1,6 @@
 import { mapPathString } from '../utils';
 
 
-export default function transformImport(types, nodePath, state) {
-  mapPathString(types, nodePath.get('source'), state);
+export default function transformImport(nodePath, state) {
+  mapPathString(nodePath.get('source'), state);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,13 +34,13 @@ export function matchesPattern(types, calleePath, pattern) {
   return node.name === name;
 }
 
-export function mapPathString(types, nodePath, state) {
-  if (!types.isStringLiteral(nodePath)) {
+export function mapPathString(nodePath, state) {
+  if (!state.types.isStringLiteral(nodePath)) {
     return;
   }
 
   const modulePath = getRealPath(nodePath.node.value, state);
   if (modulePath) {
-    nodePath.replaceWith(types.stringLiteral(modulePath));
+    nodePath.replaceWith(state.types.stringLiteral(modulePath));
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -359,7 +359,7 @@ describe('module-resolver', () => {
         );
       });
 
-      it('should transform double backslash into a single one', () => {
+      it('should transform a double backslash into a single one', () => {
         testWithImport(
           'single-backslash',
           // This is a string literal, so in the code it will actually be "pas\\sed"
@@ -416,7 +416,10 @@ describe('module-resolver', () => {
             root: './testproject/src',
             cwd: path.resolve('test'),
             alias: {
-              test: './testproject/test',
+              constantsRelative: './constants',
+              constantsNonRelative: 'constants',
+              '^constantsRegExpRelative(.*)': './constants\\1',
+              '^constantsNonRelative(.*)': 'constants\\1',
             },
           }],
         ],
@@ -430,10 +433,34 @@ describe('module-resolver', () => {
         );
       });
 
-      it('should alias the sub file path', () => {
+      it('should alias the relative path while ignoring cwd and root', () => {
         testWithImport(
-          'test/tools',
-          './test/testproject/test/tools',
+          'constantsRelative/actions',
+          './test/constants/actions',
+          transformerOpts,
+        );
+      });
+
+      it('should alias the non-relative path while ignoring cwd and root', () => {
+        testWithImport(
+          'constantsNonRelative/actions',
+          'constants/actions',
+          transformerOpts,
+        );
+      });
+
+      it('should alias the relative path while ignoring cwd and root', () => {
+        testWithImport(
+          'constantsRegExpRelative/actions',
+          './constants/actions',
+          transformerOpts,
+        );
+      });
+
+      it('should alias the non-relative path while ignoring cwd and root', () => {
+        testWithImport(
+          'constantsNonRelative/actions',
+          'constants/actions',
           transformerOpts,
         );
       });
@@ -487,7 +514,7 @@ describe('module-resolver', () => {
         [plugin, {
           root: './src',
           alias: {
-            test: './test',
+            actions: 'constants/actions',
           },
           cwd: 'babelrc',
         }],
@@ -505,8 +532,8 @@ describe('module-resolver', () => {
 
     it('should alias the sub file path', () => {
       testWithImport(
-        'test/tools',
-        '../test/tools',
+        'actions',
+        'constants/actions',
         transformerOpts,
       );
     });


### PR DESCRIPTION
This is the last one of my refactors. Changes here:
- moving `normalizeOptions` to a separate file, which separates it from the visitor code. Makes the intent in `index.js` more clear IMO, because there is a lot less to look at now.
- making resolvers into a pipeline-ish thing: there was a pattern which was repeated three times and so it made sense to let JS go over the resolvers in the right order (a bit more clear now - one array with all of them) instead of repeating the code.
- moving `types` into state - a thing I experimented with in another plugin. It allows moving the visitor code out of the main export function, which I also did.
- adding more tests for yet undocumented scenarios.

Edit: added the point about `types`.
Edit: added the point about the tests.