### PR TITLE
Add option to use a transform function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Specify the plugin in your `.babelrc` with the custom root or alias. Here's an e
 - `extensions`: Array of extensions used in the resolver. Override the default extensions (`['.js', '.jsx', '.es', '.es6']`).
 - `cwd`: By default, the working directory is the one used for the resolver, but you can override it for your project.
     - The custom value `babelrc` will make the plugin look for the closest babelrc configuration based on the file to parse.
-
+- `transform`: A function to transform the path. E.g. `transform: oldPath => 'new/' + oldPath`
 ### Regular expression alias
 
 It is possible to specify an alias using a regular expression. To do that, either start an alias with `'^'` or end it with `'$'`:

--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -87,6 +87,10 @@ function getRealPathFromRegExpConfig(sourcePath, regExps) {
   return aliasedSourceFile;
 }
 
+function getRealPathFromTransformFunction(sourcePath, transformer) {
+  return transformer && transformer(sourcePath);
+}
+
 export default function getRealPath(sourcePath, currentFile, opts) {
   if (sourcePath[0] === '.') {
     return sourcePath;
@@ -100,6 +104,7 @@ export default function getRealPath(sourcePath, currentFile, opts) {
   const rootDirs = pluginOpts.root || [];
   const regExps = pluginOpts.regExps;
   const alias = pluginOpts.alias || {};
+  const transformer = pluginOpts.transform;
 
   const sourceFileFromRoot = getRealPathFromRootConfig(
     sourcePath, absCurrentFile, rootDirs, cwd, extensions,
@@ -120,6 +125,13 @@ export default function getRealPath(sourcePath, currentFile, opts) {
   );
   if (sourceFileFromRegExp) {
     return sourceFileFromRegExp;
+  }
+
+  const sourceFileFromTransformFunction = getRealPathFromTransformFunction(
+    sourcePath, transformer,
+  );
+  if (sourceFileFromTransformFunction) {
+    return sourceFileFromTransformFunction;
   }
 
   return sourcePath;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -461,6 +461,27 @@ describe('module-resolver', () => {
     });
   });
 
+  describe('transform', () => {
+    describe('should transform path using supplied function', () => {
+      const transformerOpts = {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            transform: sourcePath => `${sourcePath}.jsx`,
+          }],
+        ],
+      };
+
+      describe('basic resolve', () => {
+        testRequireImport(
+          'a/file/name',
+          'a/file/name.jsx',
+          transformerOpts,
+        );
+      });
+    });
+  });
+
   describe('with custom cwd', () => {
     describe('custom value', () => {
       const transformerOpts = {


### PR DESCRIPTION
I was using this plugin and thought it would be handy to add an option for a transform function to operate on the path. I use something similar as a resolver plugin in webpack, but for my ava tests it made more sense to do it in a babel plugin. Interested in feedback re: whether or not you feel this belongs in your plugin.