### PR TITLE
Prevent double application of the transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-node_modules/
+/node_modules/
 npm-debug.log
 lib/
 coverage/

--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -78,26 +78,6 @@ const resolvers = [
   getRealPathFromAliasConfig,
 ];
 
-function getResolvedPath(sourcePath, currentFile, opts) {
-  let resolvedPath = null;
-
-  resolvers.some((resolver) => {
-    resolvedPath = resolver(sourcePath, currentFile, opts);
-    return resolvedPath !== null;
-  });
-
-  return resolvedPath;
-}
-
-function checkIfDoubleApplicationPossible(sourcePath, resolvedPath, currentFile, opts) {
-  if (resolvedPath !== null) {
-    const resolvedAgainPath = getResolvedPath(resolvedPath, currentFile, opts);
-    if (resolvedAgainPath !== null && resolvedAgainPath !== resolvedPath) {
-      warn(`Resolving "${sourcePath}" may give different results if done multiple times. Remove cycles from the configuration or alias to absolute paths.`);
-    }
-  }
-}
-
 export default function getRealPath(sourcePath, { file, opts }) {
   if (sourcePath[0] === '.') {
     return sourcePath;
@@ -106,11 +86,12 @@ export default function getRealPath(sourcePath, { file, opts }) {
   // File param is a relative path from the environment current working directory
   // (not from cwd param)
   const currentFile = path.resolve(file.opts.filename);
-  const resolvedPath = getResolvedPath(sourcePath, currentFile, opts);
+  let resolvedPath = null;
 
-  if (process.env.NODE_ENV !== 'production') {
-    checkIfDoubleApplicationPossible(sourcePath, resolvedPath, currentFile, opts);
-  }
+  resolvers.some((resolver) => {
+    resolvedPath = resolver(sourcePath, currentFile, opts);
+    return resolvedPath !== null;
+  });
 
   return resolvedPath;
 }

--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -78,6 +78,26 @@ const resolvers = [
   getRealPathFromAliasConfig,
 ];
 
+function getResolvedPath(sourcePath, currentFile, opts) {
+  let resolvedPath = null;
+
+  resolvers.some((resolver) => {
+    resolvedPath = resolver(sourcePath, currentFile, opts);
+    return resolvedPath !== null;
+  });
+
+  return resolvedPath;
+}
+
+function checkIfDoubleApplicationPossible(sourcePath, resolvedPath, currentFile, opts) {
+  if (resolvedPath !== null) {
+    const resolvedAgainPath = getResolvedPath(resolvedPath, currentFile, opts);
+    if (resolvedAgainPath !== null && resolvedAgainPath !== resolvedPath) {
+      warn(`Resolving "${sourcePath}" may give different results if done multiple times. Remove cycles from the configuration or alias to absolute paths.`);
+    }
+  }
+}
+
 export default function getRealPath(sourcePath, { file, opts }) {
   if (sourcePath[0] === '.') {
     return sourcePath;
@@ -86,12 +106,11 @@ export default function getRealPath(sourcePath, { file, opts }) {
   // File param is a relative path from the environment current working directory
   // (not from cwd param)
   const currentFile = path.resolve(file.opts.filename);
-  let resolvedPath = null;
+  const resolvedPath = getResolvedPath(sourcePath, currentFile, opts);
 
-  resolvers.some((resolver) => {
-    resolvedPath = resolver(sourcePath, currentFile, opts);
-    return resolvedPath !== null;
-  });
+  if (process.env.NODE_ENV !== 'production') {
+    checkIfDoubleApplicationPossible(sourcePath, resolvedPath, currentFile, opts);
+  }
 
   return resolvedPath;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,7 +50,12 @@ export function mapPathString(nodePath, state) {
 
   const modulePath = getRealPath(nodePath.node.value, state);
   if (modulePath) {
+    if (nodePath.node.pathResolved) {
+      return;
+    }
+
     nodePath.replaceWith(state.types.stringLiteral(modulePath));
+    nodePath.node.pathResolved = true;
   }
 }
 


### PR DESCRIPTION
There were problems described e.g. in #167 wrt. the possible double application stemming from a not-exactly-good configuration. I think we should warn when this _may_ happen and consider this an anti-pattern.

Example of such configuration:
```
alias: {
  'react-native-vector-icons': '@expo/vector-icons',
  '@expo/vector-icons/lib/create-icon-set': 'react-native-vector-icons/lib/create-icon-set',
  '@expo/vector-icons/lib/icon-button': 'react-native-vector-icons/lib/icon-button'
}
```

If there's a path `react-native-vector-icons/lib/create-icon-set` then first application of the plugin will transform it to `@expo/vector-icons/lib/create-icon-set`, and another application will result in `react-native-vector-icons/lib/create-icon-set`. This is actually causing trouble for users in some cases.

---

I feel the message could be greatly improved. Any suggestions?

Also this may deserve a section in the README describing the problem, which we could refer to in the message.