### PR TITLE
Fix a case when the alias is not a proper sub path

### DIFF
--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -83,7 +83,7 @@ function normalizeAlias(opts) {
     opts.alias = aliasKeys.map(key => (
       isRegExp(key) ?
         getAliasPair(key, alias[key]) :
-        getAliasPair(`^${key}((?:/|$).*)`, `${alias[key]}\\1`)
+        getAliasPair(`^${key}(/.*|)$`, `${alias[key]}\\1`)
     ));
   } else {
     opts.alias = [];

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -83,7 +83,7 @@ function normalizeAlias(opts) {
     opts.alias = aliasKeys.map(key => (
       isRegExp(key) ?
         getAliasPair(key, alias[key]) :
-        getAliasPair(`^${key}((?:/|).*)`, `${alias[key]}\\1`)
+        getAliasPair(`^${key}((?:/|$).*)`, `${alias[key]}\\1`)
     ));
   } else {
     opts.alias = [];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -274,6 +274,14 @@ describe('module-resolver', () => {
         );
       });
 
+      it('should not alias if there is no proper sub path', () => {
+        testWithImport(
+          'components_dummy',
+          'components_dummy',
+          aliasTransformerOpts,
+        );
+      });
+
       it('should alias the sub file path', () => {
         testWithImport(
           'test/tools',
@@ -288,6 +296,14 @@ describe('module-resolver', () => {
         testWithImport(
           'awesome/components',
           './test/testproject/src/components',
+          aliasTransformerOpts,
+        );
+      });
+
+      it('should not alias if there is no proper sub path', () => {
+        testWithImport(
+          'awesome/componentss',
+          'awesome/componentss',
           aliasTransformerOpts,
         );
       });


### PR DESCRIPTION
I noticed it by an accident, but it seems fairly serious. There were no tests for this.

For example if an alias exists for `components`, then `components_dummy` should not be aliased, only `components` or `components/*`.