### PR TITLE
Add the resolvePath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Are you a plugin author (e.g. IDE integration)? We have [documented the exposed 
     - The custom value `babelrc` will make the plugin look for the closest babelrc configuration based on the file to parse.
     - The custom value `packagejson` will make the plugin look for the closest `package.json` based on the file to parse.
 - `transformFunctions`: Array of functions and methods that will have their first argument transformed. By default those methods are: `require`, `require.resolve`, `System.import`, `jest.genMockFromModule`, `jest.mock`, `jest.unmock`, `jest.doMock`, `jest.dontMock`.
+- `resolvePath(sourcePath, currentFile, opts)`: A function that is called for each path in the file. By default module-resolver is using an internal function, exposed like so: `import { resolvePath } from 'babel-plugin-module-resolver`'. The `opts` argument is the options object that is passed through the Babel config.
 
 ### Regular expression alias
 

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -6,6 +6,8 @@ import findBabelConfig from 'find-babel-config';
 import glob from 'glob';
 import pkgUp from 'pkg-up';
 
+import defaultResolvePath from './resolvePath';
+
 
 const defaultExtensions = ['.js', '.jsx', '.es', '.es6', '.mjs'];
 const defaultTransformedFunctions = [
@@ -117,6 +119,7 @@ export default createSelector(
     const alias = normalizeAlias(opts.alias);
     const transformFunctions = normalizeTransformedFunctions(opts.transformFunctions);
     const extensions = opts.extensions || defaultExtensions;
+    const resolvePath = opts.resolvePath || defaultResolvePath;
 
     return {
       cwd,
@@ -124,6 +127,7 @@ export default createSelector(
       alias,
       transformFunctions,
       extensions,
+      resolvePath,
     };
   },
 );

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,6 @@
 import path from 'path';
 
 import resolve from 'resolve';
-import resolvePath from './resolvePath';
 
 
 export function nodeResolvePath(modulePath, basedir, extensions) {
@@ -50,9 +49,8 @@ export function mapPathString(nodePath, state) {
 
   const sourcePath = nodePath.node.value;
   const currentFile = state.file.opts.filename;
-  const opts = state.opts;
 
-  const modulePath = resolvePath(sourcePath, currentFile, opts);
+  const modulePath = state.normalizedOpts.resolvePath(sourcePath, currentFile, state.opts);
   if (modulePath) {
     if (nodePath.node.pathResolved) {
       return;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -847,4 +847,44 @@ describe('module-resolver', () => {
       });
     });
   });
+
+  describe('resolvePath', () => {
+    it('should work with a custom function', () => {
+      const rootTransformerOpts = {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            root: './test/testproject/src',
+            resolvePath() {
+              return 'real path';
+            },
+          }],
+        ],
+      };
+
+      testWithImport(
+        'app',
+        'real path',
+        rootTransformerOpts,
+      );
+    });
+
+    it('should work with the original function', () => {
+      const rootTransformerOpts = {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            root: './test/testproject/src',
+            resolvePath,
+          }],
+        ],
+      };
+
+      testWithImport(
+        'app',
+        './test/testproject/src/app',
+        rootTransformerOpts,
+      );
+    });
+  });
 });


### PR DESCRIPTION
Adds the `getRealPath` option, thus solving the #165 issue.

I used the `getRealPath` name, but maybe just `transform` would be good? But then `getRealPath` is exposed in the module... I just have a tiny doubt about the name. Maybe it would be good to instead expose `transform` and use that instead of `getRealPath` consistently.

I'm marking this as WIP because it depends on the changes from #194.