### PR TITLE
make alias config take precedence over root config

### DIFF
--- a/src/resolvePath.js
+++ b/src/resolvePath.js
@@ -76,8 +76,8 @@ function resolvePathFromAliasConfig(sourcePath, currentFile, opts) {
 }
 
 const resolvers = [
-  resolvePathFromRootConfig,
   resolvePathFromAliasConfig,
+  resolvePathFromRootConfig,
 ];
 
 export default function resolvePath(sourcePath, currentFile, opts) {


### PR DESCRIPTION
Not sure if this breaks anything else, but I bet most users want `alias` to take precedence over `root` because `alias` is more specific.

If you don't want this to be the default for some reason, could I add an option to reverse the precedence in another PR?