### PR TITLE
feat: Make alias config take precedence over root config

### DIFF
--- a/src/resolvePath.js
+++ b/src/resolvePath.js
@@ -76,8 +76,8 @@ function resolvePathFromAliasConfig(sourcePath, currentFile, opts) {
 }
 
 const resolvers = [
-  resolvePathFromRootConfig,
   resolvePathFromAliasConfig,
+  resolvePathFromRootConfig,
 ];
 
 export default function resolvePath(sourcePath, currentFile, opts) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -264,23 +264,23 @@ describe('module-resolver', () => {
     });
 
     describe('root and alias', () => {
-      const rootTransformerOpts = {
+      const aliasTransformerOpts = {
         babelrc: false,
         plugins: [
           [plugin, {
-            root: './test/testproject/src',
+            root: './test/fakepath/',
             alias: {
-              constants: 'constants/actions',
+              constants: './test/testproject/src/constants',
             },
           }],
         ],
       };
 
-      it('should resolve the path using root first and alias otherwise', () => {
+      it('should resolve the path using alias first and root otherwise', () => {
         testWithImport(
           'constants',
           './test/testproject/src/constants',
-          rootTransformerOpts,
+          aliasTransformerOpts,
         );
       });
     });


### PR DESCRIPTION
Following this https://github.com/tleunen/babel-plugin-module-resolver/pull/218

BREAKING CHANGE: This makes alias taking precedence over the root config because it's usually more specific. It might break for some users. Although, I don't think most users will be affected by this.