### PR TITLE
Set name of plugin for eslint integration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const visitor = {
 };
 
 export default ({ types }) => ({
+  name: 'module-resolver',
   pre(file) {
     this.types = types;
 


### PR DESCRIPTION
In both [babel 6](https://github.com/babel/babel/blob/6.x/packages/babel-core/src/transformation/plugin.js#L16) and [babel 7](https://github.com/babel/babel/blob/master/packages/babel-core/src/config/plugin.js#L34) the key is set to the name if the plugin defines one.

As the eslint resolver is now checking for [the key](https://github.com/tleunen/eslint-import-resolver-babel-module/blob/master/src/index.js#L26) it is important to set the name here.
Currently only babel-configs work that reference the plugin with `'module-resolver'`.
With this change it does not matter how the plugin is used in the config (`require`, `require.resolve`, `'babel-plugin-module-resolver'`) as the key will always be set to the name.

Fixes tleunen/eslint-import-resolver-babel-module#70