### PR TITLE
Allow passing a function as a RegExp substitute

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -66,6 +66,30 @@ You can reference the n-th matched group with `'\\n'` (`'\\0'` refers to the who
 
 To use the backslash character (`\`) just escape it like so: `'\\\\'` (double escape is needed because of JSON already using `\` for escaping).
 
+### Regular expressions with a function
+
+If you need even more power over the aliased path, you can pass a function in the alias configuration:
+
+```js
+module.exports = {
+  plugins: [
+    ["module-resolver", {
+      alias: {
+        "^@namespace/foo-(.+)": ([, name]) => path.join('packages', name)
+      }
+    }]
+  ]
+}
+```
+
+Using the config from this example `'@namespace/foo-bar'` will become `'packages/bar'` or `'packages\\bar'` depending on the OS.
+
+The only argument is the result of calling `RegExp.prototype.exec` on the matched path. It's an array with the matched string and all matched groups.
+
+Because the function is only called when there is a match, the argument can never be `null`.
+
+*Important: a function can only be used with regular expressions.*
+
 ## extensions
 
 An array of extensions used in the resolver.
@@ -95,7 +119,7 @@ Array of functions and methods that will have their first argument transformed. 
   "plugins": [
     ["module-resolver", {
       "transformFunctions": [
-          "require", 
+          "require",
           "require.resolve",
           "System.import",
           "jest.genMockFromModule",

--- a/DOCS.md
+++ b/DOCS.md
@@ -66,7 +66,7 @@ You can reference the n-th matched group with `'\\n'` (`'\\0'` refers to the who
 
 To use the backslash character (`\`) just escape it like so: `'\\\\'` (double escape is needed because of JSON already using `\` for escaping).
 
-### Regular expressions with a function
+### Passing a substitute function
 
 If you need even more power over the aliased path, you can pass a function in the alias configuration:
 
@@ -75,6 +75,7 @@ module.exports = {
   plugins: [
     ["module-resolver", {
       alias: {
+        "foo": ([, name]) => path.join('bar', name)
         "^@namespace/foo-(.+)": ([, name]) => path.join('packages', name)
       }
     }]
@@ -82,13 +83,13 @@ module.exports = {
 }
 ```
 
-Using the config from this example `'@namespace/foo-bar'` will become `'packages/bar'` or `'packages\\bar'` depending on the OS.
+Using the config from this example:
+* `'foo/baz'` will become `'bar/baz'` or `'bar\\baz'`
+* `'@namespace/foo-bar'` will become `'packages/bar'` or `'packages\\bar'`
 
 The only argument is the result of calling `RegExp.prototype.exec` on the matched path. It's an array with the matched string and all matched groups.
 
 Because the function is only called when there is a match, the argument can never be `null`.
-
-*Important: a function can only be used with regular expressions.*
 
 ## extensions
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -75,8 +75,8 @@ module.exports = {
   plugins: [
     ["module-resolver", {
       alias: {
-        "foo": ([, name]) => path.join('bar', name)
-        "^@namespace/foo-(.+)": ([, name]) => path.join('packages', name)
+        "foo": ([, name]) => `bar${name}`,
+        "^@namespace/foo-(.+)": ([, name]) => `packages/${name}`
       }
     }]
   ]
@@ -84,8 +84,9 @@ module.exports = {
 ```
 
 Using the config from this example:
-* `'foo/baz'` will become `'bar/baz'` or `'bar\\baz'`
-* `'@namespace/foo-bar'` will become `'packages/bar'` or `'packages\\bar'`
+* `'foo'` will become `'bar'` (`name` is empty)
+* `'foo/baz'` will become `'bar/baz'` (`name` includes the slash in this case)
+* `'@namespace/foo-bar'` will become `'packages/bar'`
 
 The only argument is the result of calling `RegExp.prototype.exec` on the matched path. It's an array with the matched string and all matched groups.
 

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -79,6 +79,10 @@ function normalizeRoot(optsRoot, cwd) {
 }
 
 function getAliasPair(key, value) {
+  if (typeof value === 'function') {
+    return [new RegExp(key), value];
+  }
+
   const parts = value.split('\\\\');
 
   function substitute(execResult) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -492,6 +492,45 @@ describe('module-resolver', () => {
       });
     });
 
+    describe('with a regular expression and a function', () => {
+      const mockSubstitute = jest.fn();
+      const regExpSubsituteOpts = {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            alias: {
+              '^@regexp-function/(.+)': mockSubstitute,
+            },
+          }],
+        ],
+      };
+
+      beforeEach(() => {
+        mockSubstitute.mockClear();
+      });
+
+      it('should call the substitute with the right arguments', () => {
+        mockSubstitute.mockReturnValue('./test/testproject/test');
+
+        testWithImport(
+          '@regexp-function/something',
+          './test/testproject/test',
+          regExpSubsituteOpts,
+        );
+
+        expect(mockSubstitute.mock.calls.length).toBe(1);
+
+        const execResult = Object.assign(
+          ['@regexp-function/something', 'something'],
+          {
+            index: 0,
+            input: '@regexp-function/something',
+          },
+        );
+        expect(mockSubstitute).toBeCalledWith(execResult);
+      });
+    });
+
     describe('with the plugin applied twice', () => {
       const doubleAliasTransformerOpts = {
         babelrc: false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -492,13 +492,14 @@ describe('module-resolver', () => {
       });
     });
 
-    describe('with a regular expression and a function', () => {
+    describe('with a function', () => {
       const mockSubstitute = jest.fn();
       const regExpSubsituteOpts = {
         babelrc: false,
         plugins: [
           [plugin, {
             alias: {
+              'basic-function': mockSubstitute,
               '^@regexp-function/(.+)': mockSubstitute,
             },
           }],
@@ -509,7 +510,28 @@ describe('module-resolver', () => {
         mockSubstitute.mockClear();
       });
 
-      it('should call the substitute with the right arguments', () => {
+      it('should call the substitute with the right arguments (basic)', () => {
+        mockSubstitute.mockReturnValue('./test/testproject/test');
+
+        testWithImport(
+          'basic-function/something',
+          './test/testproject/test',
+          regExpSubsituteOpts,
+        );
+
+        expect(mockSubstitute.mock.calls.length).toBe(1);
+
+        const execResult = Object.assign(
+          ['basic-function/something', '/something'],
+          {
+            index: 0,
+            input: 'basic-function/something',
+          },
+        );
+        expect(mockSubstitute).toBeCalledWith(execResult);
+      });
+
+      it('should call the substitute with the right arguments (regexp)', () => {
         mockSubstitute.mockReturnValue('./test/testproject/test');
 
         testWithImport(


### PR DESCRIPTION
This implements a feature requested in #242.