### PR TITLE
Use base env instead

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,6 @@
 {
   "presets": [
-    ["env", {
-      "targets": {
-        "node": 6
-      },
-      "loose": true,
-      "useBuiltIns": true
-    }]
+    "env"
   ],
   "plugins": [
     "transform-object-rest-spread"


### PR DESCRIPTION
There is a problem requiring this plugin in one of my browserify project. Turns out babelify isn't transforming the syntax of this (unless I shove babelify into global transforms), and it's due to that Node >= v6.x.x does support `let` and `const`.