### PR TITLE
Fix path transformation for dot files that are sibling to current file

### DIFF
--- a/src/resolvePath.js
+++ b/src/resolvePath.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { warn } from './log';
 import mapToRelative from './mapToRelative';
 import normalizeOptions from './normalizeOptions';
-import { nodeResolvePath, replaceExtension, toLocalPath, toPosixPath } from './utils';
+import { nodeResolvePath, replaceExtension, isRelativePath, toLocalPath, toPosixPath } from './utils';
 
 function getRelativePath(sourcePath, currentFile, absFileInRoot, opts) {
   const realSourceFileExtension = path.extname(absFileInRoot);
@@ -64,7 +64,7 @@ function resolvePathFromAliasConfig(sourcePath, currentFile, opts) {
     return null;
   }
 
-  if (aliasedSourceFile[0] === '.') {
+  if (isRelativePath(aliasedSourceFile)) {
     return toLocalPath(toPosixPath(
       mapToRelative(opts.cwd, currentFile, aliasedSourceFile)),
     );
@@ -83,7 +83,7 @@ const resolvers = [
 ];
 
 export default function resolvePath(sourcePath, currentFile, opts) {
-  if (sourcePath[0] === '.') {
+  if (isRelativePath(sourcePath)) {
     return sourcePath;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,14 +11,20 @@ export function nodeResolvePath(modulePath, basedir, extensions) {
   }
 }
 
+export function isRelativePath(nodePath) {
+  return nodePath.match(/^\.?\.\//);
+}
+
 export function toPosixPath(modulePath) {
   return modulePath.replace(/\\/g, '/');
 }
 
 export function toLocalPath(modulePath) {
-  return modulePath
-    .replace(/\/index$/, '') // remove trailing /index
-    .replace(/^(?!\.)/, './'); // insert `./` to make it a local path
+  let localPath = modulePath.replace(/\/index$/, ''); // remove trailing /index
+  if (!isRelativePath(localPath)) {
+    localPath = `./${localPath}`; // insert `./` to make it a relative path
+  }
+  return localPath;
 }
 
 export function stripExtension(modulePath, stripExtensions) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -769,6 +769,45 @@ describe('module-resolver', () => {
         );
       });
     });
+
+    describe('dot files', () => {
+      const dotFileAliasTransformerOpts = {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            alias: {
+              '.babel': 'babel-core',
+              elintrc: './.eslintrc',
+              folderdot: './src/folder.',
+            },
+          }],
+        ],
+      };
+
+      it('should not match folder names with dot at end', () => {
+        testWithImport(
+          'folderdot/file',
+          './src/folder./file',
+          dotFileAliasTransformerOpts,
+        );
+      });
+
+      it('should resolve alias with dot', () => {
+        testWithImport(
+          '.babel/register',
+          'babel-core/register',
+          dotFileAliasTransformerOpts,
+        );
+      });
+
+      it('should resolve sibling dot files using alias', () => {
+        testWithImport(
+          'elintrc',
+          './.eslintrc',
+          dotFileAliasTransformerOpts,
+        );
+      });
+    });
   });
 
   describe('with custom cwd', () => {


### PR DESCRIPTION
Currently the code checks for a relative path by checking if it starts with a dot. This incorrectly identifies a path resolved dot file e.g. `.eslintrc` as a relative path. So it does NOT transform the path to relative path such as `./.eslintric`. This is fixed by using a regex that checks for a `./` or `../` at the start of the path.