### PR TITLE
[babel@v7] Not use `process.cwd` to `cwd`

### DIFF
--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -52,7 +52,7 @@ function normalizeCwd(optsCwd, currentFile) {
     cwd = optsCwd;
   }
 
-  return cwd || process.cwd();
+  return cwd || path.resolve(__dirname, './../../../');
 }
 
 function normalizeRoot(optsRoot, cwd) {


### PR DESCRIPTION
In `jest`, it will use `cache` to run the `babel`.
As a result, `process.cwd` will get the cache folder. This is not the folder of the project.
I think this is the best way to use `path.resolve` to get the folder of the project.
Otherwise, the user need to set the `.babelrc.js` to be:
```js
...
['module-resolver', {
  cwd: __dirname,
}]
...
```