### PR TITLE
Run plugin also on Program:exit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,9 @@ const visitor = {
     enter(programPath, state) {
       programPath.traverse(importVisitors, state);
     },
+    exit(programPath, state) {
+      programPath.traverse(importVisitors, state);
+    },
   },
 };
 
@@ -29,7 +32,14 @@ export default ({ types }) => ({
 
     const currentFile = file.opts.filename;
     this.normalizedOpts = normalizeOptions(currentFile, this.opts);
+    // We need to keep track of all handled nodes so we do not try to transform them twice,
+    // because we run before (enter) and after (exit) all nodes are handled
+    this.moduleResolverVisited = new Set();
   },
 
   visitor,
+
+  post() {
+    this.moduleResolverVisited.clear();
+  },
 });

--- a/src/transformers/call.js
+++ b/src/transformers/call.js
@@ -6,12 +6,17 @@ import {
 
 
 export default function transformCall(nodePath, state) {
+  if (state.moduleResolverVisited.has(nodePath)) {
+    return;
+  }
+
   const calleePath = nodePath.get('callee');
   const isNormalCall = state.normalizedOpts.transformFunctions.some(
     pattern => matchesPattern(state.types, calleePath, pattern),
   );
 
   if (isNormalCall || isImportCall(state.types, nodePath)) {
+    state.moduleResolverVisited.add(nodePath);
     mapPathString(nodePath.get('arguments.0'), state);
   }
 }

--- a/src/transformers/import.js
+++ b/src/transformers/import.js
@@ -2,5 +2,10 @@ import { mapPathString } from '../utils';
 
 
 export default function transformImport(nodePath, state) {
+  if (state.moduleResolverVisited.has(nodePath)) {
+    return;
+  }
+  state.moduleResolverVisited.add(nodePath);
+
   mapPathString(nodePath.get('source'), state);
 }

--- a/test/dynamicImport.test.js
+++ b/test/dynamicImport.test.js
@@ -56,4 +56,26 @@ describe('import()', () => {
 
     expect(result.code).toBe('import("").then(() => {}).catch(() => {});');
   });
+
+  it('should handle imports added by other transforms', () => {
+    const options = {
+      ...transformerOpts,
+      plugins: [
+        function fakePlugin({ types }) {
+          return {
+            visitor: {
+              Identifier(path) {
+                path.replaceWith(types.Import());
+              },
+            },
+          };
+        },
+        ...transformerOpts.plugins,
+      ],
+    };
+    const code = 'boo("components/Header/SubHeader");';
+    const result = transform(code, options);
+
+    expect(result.code).toBe('import("./test/testproject/src/components/Header/SubHeader");');
+  });
 });


### PR DESCRIPTION
We have the usecase that one of our own transforms adds dynamic imports with paths which need to be replaced by this plugin.

This wasn't working because this plugin is run on Program:enter before all other plugins are executed.
I changed it so that the plugin now runs on both enter and exit to handle both of the usecases:

- Other plugin wants to resolve/use path to module from import/require (needs replacement happen before -> `Program:enter`)
- Other plugin inserts a new import/require (needs replacement happen afterwards -> `Program:exit`)

In order to avoid double transformation I added a list of already visited paths, so that each path only gets visited/transformed once.