### PR TITLE
Fix order for React Native

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -237,7 +237,7 @@ To let the packager resolve the right module for each platform, you have to add 
       "module-resolver",
       {
         "root": ["./src"],
-        "extensions": [".js", ".ios.js", ".android.js"]
+        "extensions": [".ios.js", ".android.js", ".js", ".json"]
       }
     ]
   ]


### PR DESCRIPTION
Related to #297, apparently with Babel 7 (which will land with next version of RN) the order or the extensions "matters" so better to suggest the correct order in the DOC