### PR TITLE
Fix AppVeyor config + drop support for node 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ workflows:
   version: 2
   test_all:
     jobs:
-      - test_with_node_4
       - test_with_node_6
       - test_with_node_8
       - test_with_node_9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,5 @@
 version: 2
 jobs:
-  test_with_node_4:
-    docker:
-      - image: circleci/node:4
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm install
-      - run:
-          name: Test
-          command: npm test
   test_with_node_6:
     docker:
       - image: circleci/node:6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,17 @@ jobs:
           command: npm install
       - run:
           name: Test
+          command: npm test
+  test_with_node_10:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm install
+      - run:
+          name: Test
           command: npm run test:coverage
       - run:
           name: Deploy coverage
@@ -43,3 +54,4 @@ workflows:
       - test_with_node_6
       - test_with_node_8
       - test_with_node_9
+      - test_with_node_10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
     - nodejs_version: '6'
     - nodejs_version: '8'
     - nodejs_version: '9'
+    - nodejs_version: '10'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true
-  - npm -g install npm@latest
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: '4'
     - nodejs_version: '6'
     - nodejs_version: '8'
     - nodejs_version: '9'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/tleunen/babel-plugin-module-resolver.git"
   },
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.0.0"
   },
   "files": [
     "lib"


### PR DESCRIPTION
It seems that the current AppVeyor config is broken because npm received an upgrade which breaks the build (and it shouldn't). The culprit is the line which installs the latest version of npm (while being used e.g. with node 4). It might be worth to make the config future-proof instead.