### PR TITLE
Add eslint-plugin-module-resolver link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Are you a plugin author (e.g. IDE integration)? We have [documented the exposed 
 
 ## ESLint plugin
 
-If you're using ESLint, you should use [eslint-plugin-import][eslint-plugin-import], and [eslint-import-resolver-babel-module][eslint-import-resolver-babel-module] to remove falsy unresolved modules.
+If you're using ESLint, you should use [eslint-plugin-import][eslint-plugin-import], and [eslint-import-resolver-babel-module][eslint-import-resolver-babel-module] to remove falsy unresolved modules. If you want to have warnings when aliased modules are being imported by their relative paths, you can use [eslint-plugin-module-resolver](https://github.com/HeroProtagonist/eslint-plugin-module-resolver). 
 
 ## Editors autocompletion
 


### PR DESCRIPTION
Hello!

Your library is great! I created an ESLint plugin to work with your module. I find that team members may not be aware of the aliases, so to keep everyone on the same page this rule will warn when aliased modules are being pulled in using relative paths. https://github.com/HeroProtagonist/eslint-plugin-module-resolver. Feel free to close this PR if you do not want it in, but thought others may find it useful.

Thanks!