### PR TITLE
fix: Relative file path imports now supports extensions

### DIFF
--- a/src/mapToAbsolute.js
+++ b/src/mapToAbsolute.js
@@ -1,0 +1,10 @@
+import path from 'path';
+
+import { toPosixPath } from './utils';
+
+export default function mapToAbsolute(currentFile, relativePath) {
+  const currentDirectory = path.dirname(currentFile);
+  const absolutePath = path.resolve(currentDirectory, relativePath);
+  
+  return toPosixPath(absolutePath);
+}

--- a/src/resolvePath.js
+++ b/src/resolvePath.js
@@ -2,8 +2,9 @@ import path from 'path';
 
 import { warn } from './log';
 import mapToRelative from './mapToRelative';
+import mapToAbsolute from './mapToAbsolute';
 import normalizeOptions from './normalizeOptions';
-import { nodeResolvePath, replaceExtension, isRelativePath, toLocalPath, toPosixPath } from './utils';
+import { nodeResolvePath, nodeResolveRelativePath, replaceExtension, isRelativePath, toLocalPath, toPosixPath } from './utils';
 
 function getRelativePath(sourcePath, currentFile, absFileInRoot, opts) {
   const realSourceFileExtension = path.extname(absFileInRoot);
@@ -77,13 +78,27 @@ function resolvePathFromAliasConfig(sourcePath, currentFile, opts) {
   return aliasedSourceFile;
 }
 
+function resolvePathFromRelativeConfig(sourcePath, currentFile, opts) {
+  if (isRelativePath(sourcePath)) {
+    const absFilePath = mapToAbsolute(currentFile, sourcePath);
+    const resolvedSourceFile = nodeResolveRelativePath(absFilePath, opts.extensions);
+
+    if (resolvedSourceFile) {
+      return getRelativePath(sourcePath, currentFile, resolvedSourceFile, opts);
+    }
+  }
+
+  return null;
+}
+
 const resolvers = [
   resolvePathFromAliasConfig,
+  resolvePathFromRelativeConfig,
   resolvePathFromRootConfig,
 ];
 
 export default function resolvePath(sourcePath, currentFile, opts) {
-  if (isRelativePath(sourcePath)) {
+  if (isRelativePath(sourcePath) && path.extname(sourcePath)) {
     return sourcePath;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,14 @@ export function nodeResolvePath(modulePath, basedir, extensions) {
   }
 }
 
+export function nodeResolveRelativePath(modulePath, extensions) {
+  try {
+    return resolve.sync(modulePath, { extensions });
+  } catch (e) {
+    return null;
+  }
+}
+
 export function isRelativePath(nodePath) {
   return nodePath.match(/^\.?\.\//);
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -254,6 +254,22 @@ describe('module-resolver', () => {
         );
       });
 
+      it('should not resolve the relative file path with an unknown extension', () => {
+        testWithImport(
+          './test/testproject/src/text',
+          './test/testproject/src/text',
+          rootTransformerOpts,
+        );
+      });
+
+      it('should resolve the relative file path with a known defined extension & strip the extension', () => {
+        testWithImport(
+          './test/testproject/src/rn',
+          './test/testproject/src/rn',
+          rootTransformerOpts,
+        );
+      });
+
       it('should resolve the file path with a known defined extension & strip the extension', () => {
         testWithImport(
           'rn',
@@ -262,9 +278,18 @@ describe('module-resolver', () => {
         );
       });
 
+
       it('should resolve the file path with an explicit extension and not strip the extension', () => {
         testWithImport(
           'rn/index.ios.js',
+          './test/testproject/src/rn/index.ios.js',
+          rootTransformerOpts,
+        );
+      });
+
+      it('should resolve the relative file path with an explicit extension and not strip the extension', () => {
+        testWithImport(
+          './test/testproject/src/rn/index.ios.js',
           './test/testproject/src/rn/index.ios.js',
           rootTransformerOpts,
         );
@@ -291,9 +316,26 @@ describe('module-resolver', () => {
         );
       });
 
+      it('should not resolve the relative file path with an unknown extension', () => {
+        testWithImport(
+          './test/testproject/src/text',
+          './test/testproject/src/text',
+          rootTransformerOpts,
+        );
+      });
+
       it('should resolve the file path with a known defined extension', () => {
         testWithImport(
           'rn',
+          './test/testproject/src/rn/index.ios.js',
+          rootTransformerOpts,
+        );
+      });
+
+
+      it('should resolve the relative file path with a known defined extension', () => {
+        testWithImport(
+          './test/testproject/src/rn/index',
           './test/testproject/src/rn/index.ios.js',
           rootTransformerOpts,
         );


### PR DESCRIPTION
Previously if a relative import was used then the plugin would make no attempt to resolve the file using the extensions provided. This was an issue if you were using an extension that NodeJs didn't automatically check for you, for example the jsx extension. Now you can import using a relative file and we will try and resolve it against all provided extensions. 

This step is done after attempting to resolve the import using the provided aliases but before using the root config. I thought that relative paths take precedence over those that are resolved relative to the root of the project. 

Let me know if I was a bit off in my implementation or if the tests are lacking. Happy to discuss and fix that up ASAP.