### PR TITLE
Add a direct link to create-react-app in the docs.

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -7,6 +7,7 @@
   * [cwd](#cwd)
   * [transformFunctions](#transformfunctions)
   * [resolvePath](#resolvepath)
+* [Usage with Create React App](#usage-with-create-react-app)
 * [Usage with React Native](#usage-with-react-native)
 * [Usage with Proxyquire](#usage-with-proxyquire)
 * [Usage with Flow](#usage-with-flow)


### PR DESCRIPTION
Thanks for maintaining this library! This makes it easier to find the section on usage with Create React App.