### PR TITLE
Remove unused "useBuiltIns" option from @babel/preset-env (which has unexpected behaviour for our case anyway)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,8 +4,7 @@
       "targets": {
         "node": 4
       },
-      "loose": true,
-      "useBuiltIns": "usage"
+      "loose": true
     }]
   ]
 }


### PR DESCRIPTION
3.1.2 has introduced breaking change (requiring `core-js`) which was caused by migration from babel@6 to babel@7 and using different option for the `useBuiltIns` option of preset-env (with different semantics than previously)

https://babeljs.io/docs/en/6.26.3/babel-preset-env#usebuiltins
https://babeljs.io/docs/en/babel-preset-env#usebuiltins-entry

Fixes #349