### PR TITLE
chore: Compile for Node 6 & Enable CI to run the tests with node 11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,13 @@
 {
   "presets": [
-    ["@babel/preset-env", {
-      "targets": {
-        "node": 4
-      },
-      "loose": true
-    }]
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": 6
+        },
+        "loose": true
+      }
+    ]
   ]
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,20 @@ jobs:
           command: npm install
       - run:
           name: Test
+          command: npm test
+      - run:
+          name: Deploy coverage
+          command: bash <(curl -s https://codecov.io/bash)
+  test_with_node_11:
+    docker:
+      - image: circleci/node:11
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm install
+      - run:
+          name: Test
           command: npm run test:coverage
       - run:
           name: Deploy coverage
@@ -55,3 +69,4 @@ workflows:
       - test_with_node_8
       - test_with_node_9
       - test_with_node_10
+      - test_with_node_11

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
     - nodejs_version: '8'
     - nodejs_version: '9'
     - nodejs_version: '10'
+    - nodejs_version: '11'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true


### PR DESCRIPTION
It's not needed to compile down to node 4 as the minimum supported node version is now v6.