### PR TITLE
feat(dev): add loglevel to configure console logging

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -203,6 +203,23 @@ module.exports = {
 
 If you want to leave some paths as-is, then you can return `undefined` or any other falsy value from the function.
 
+## loglevel
+
+One of the [NPM log level options](https://docs.npmjs.com/misc/config#loglevel) to configure console logging during build. Default is `"warn"`. Passing `"silent"` will disable all warnings for path resolution failures.
+
+```js
+module.exports = {
+  plugins: [
+    ["module-resolver", {
+      alias: {
+        "dependency-string": "module-that-does-not-exist" // warning will not log
+      },
+      loglevel: 'silent'
+    }]
+  ]
+}
+```
+
 # Usage with create-react-app
 
 create-react-app by default don't use .babelrc, so in webpack.config.dev.js, add plugins property within js loader like below. Note that plugins recieve an array.

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -132,6 +132,10 @@ function normalizeTransformedFunctions(optsTransformFunctions) {
   return [...defaultTransformedFunctions, ...optsTransformFunctions];
 }
 
+function normalizeLoglevel(optsLoglevel) {
+  return optsLoglevel || 'warn';
+}
+
 export default createSelector(
   // The currentFile should have an extension; otherwise it's considered a special value
   currentFile => (currentFile.includes('.') ? path.dirname(currentFile) : currentFile),
@@ -140,6 +144,7 @@ export default createSelector(
     const cwd = normalizeCwd(opts.cwd, currentFile);
     const root = normalizeRoot(opts.root, cwd);
     const alias = normalizeAlias(opts.alias);
+    const loglevel = normalizeLoglevel(opts.loglevel);
     const transformFunctions = normalizeTransformedFunctions(opts.transformFunctions);
     const extensions = opts.extensions || defaultExtensions;
     const stripExtensions = opts.stripExtensions || extensions;
@@ -149,6 +154,7 @@ export default createSelector(
       cwd,
       root,
       alias,
+      loglevel,
       transformFunctions,
       extensions,
       stripExtensions,

--- a/src/resolvePath.js
+++ b/src/resolvePath.js
@@ -39,9 +39,9 @@ function resolvePathFromRootConfig(sourcePath, currentFile, opts) {
   return getRelativePath(sourcePath, currentFile, absFileInRoot, opts);
 }
 
-function checkIfPackageExists(modulePath, currentFile, extensions) {
+function checkIfPackageExists(modulePath, currentFile, extensions, loglevel) {
   const resolvedPath = nodeResolvePath(modulePath, currentFile, extensions);
-  if (resolvedPath === null) {
+  if (resolvedPath === null && loglevel !== 'silent') {
     warn(`Could not resolve "${modulePath}" in file ${currentFile}.`);
   }
 }
@@ -71,7 +71,7 @@ function resolvePathFromAliasConfig(sourcePath, currentFile, opts) {
   }
 
   if (process.env.NODE_ENV !== 'production') {
-    checkIfPackageExists(aliasedSourceFile, currentFile, opts.extensions);
+    checkIfPackageExists(aliasedSourceFile, currentFile, opts.extensions, opts.loglevel);
   }
 
   return aliasedSourceFile;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -685,6 +685,28 @@ describe('module-resolver', () => {
           expect(mockWarn.mock.calls.length).toBe(0);
         });
       });
+
+      const silentLoggingOpts = {
+        babelrc: false,
+        plugins: [
+          [pluginWithMock, {
+            alias: {
+              legacy: 'npm:legacy',
+              'non-existing': 'this-package-does-not-exist',
+            },
+            loglevel: 'silent',
+          }],
+        ],
+      };
+
+      it('should respect opt loglevel:silent', () => {
+        testWithImport(
+          'legacy/lib',
+          'npm:legacy/lib',
+          silentLoggingOpts,
+        );
+          expect(mockWarn.mock.calls.length).toBe(0);
+      });
     });
 
     describe('multiple alias application', () => {


### PR DESCRIPTION
- Add `loglevel` option
- Disable missing path warning if `loglevel` is `"silent"`

We use this plugin to export a "virtual dependency" in our published modules, so that consumers of our module can override a deep dependency. We then alias the virtual module in Webpack config, not babel config. So we expect the virtual module not to exist at Babel build time.

Your plugin works great (thank you!) but it logs a lot of warnings due to our configuration, so we'd appreciate this option to quiet them.