### PR TITLE
fix: https://github.com/tleunen/babel-plugin-module-resolver/issues/381

### DIFF
--- a/src/resolvePath.js
+++ b/src/resolvePath.js
@@ -95,10 +95,6 @@ const resolvers = [
 ];
 
 export default function resolvePath(sourcePath, currentFile, opts) {
-  if (isRelativePath(sourcePath)) {
-    return sourcePath;
-  }
-
   const normalizedOpts = normalizeOptions(currentFile, opts);
 
   // File param is a relative path from the environment current working directory
@@ -111,5 +107,8 @@ export default function resolvePath(sourcePath, currentFile, opts) {
     return resolvedPath !== null;
   });
 
+  if (!resolvedPath && isRelativePath(sourcePath)) {
+    return sourcePath;
+  }
   return resolvedPath;
 }

--- a/test/dynamicImport.test.js
+++ b/test/dynamicImport.test.js
@@ -78,4 +78,21 @@ describe('import()', () => {
 
     expect(result.code).toBe('import("./test/testproject/src/components/Header/SubHeader");');
   });
+
+  it('should handle regex aliases', () => {
+    const code = 'import("./index.ts").then(() => {}).catch(() => {});';
+    const result = transform(code, {
+      babelrc: false,
+      plugins: [
+        '@babel/plugin-syntax-dynamic-import',
+        [plugin, {
+          alias: {
+            "(.+)\\.ts$": "\\1.js"
+          },
+        }],
+      ],
+    });
+
+    expect(result.code).toBe('import("./index.js").then(() => {}).catch(() => {});');
+  });
 });

--- a/test/import.test.js
+++ b/test/import.test.js
@@ -148,4 +148,21 @@ describe('import and export statement', () => {
       }
     `);
   });
+
+  describe('should resolve regex aliases', () => {
+    testImports(
+      './index.ts',
+      './index.js',
+      {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            alias: {
+              "(.+)\\.ts$": "\\1.js"
+            },
+          }],
+        ],
+      },
+    );
+  });
 });


### PR DESCRIPTION
Moves the relative path conditional under the resolvers and skip it if there is a resolver result

Add corresponding test

*https://github.com/tleunen/babel-plugin-module-resolver/issues/381*