### PR TITLE
Allow non-module resolves

### DIFF
--- a/src/mapPath.js
+++ b/src/mapPath.js
@@ -1,6 +1,6 @@
 import defaultResolvePath from './resolvePath';
 
-export default function mapPathString(nodePath, state) {
+export default function mapPathString(nodePath, state, resolveOpts) {
   if (!state.types.isStringLiteral(nodePath)) {
     return;
   }
@@ -9,7 +9,7 @@ export default function mapPathString(nodePath, state) {
   const currentFile = state.file.opts.filename;
   const resolvePath = state.normalizedOpts.customResolvePath || defaultResolvePath;
 
-  const modulePath = resolvePath(sourcePath, currentFile, state.opts);
+  const modulePath = resolvePath(sourcePath, currentFile, state.opts, resolveOpts);
   if (modulePath) {
     if (nodePath.node.pathResolved) {
       return;

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -9,20 +9,20 @@ import pkgUp from 'pkg-up';
 import { escapeRegExp } from './utils';
 
 const defaultExtensions = ['.js', '.jsx', '.es', '.es6', '.mjs'];
-const defaultTransformedFunctions = [
-  'require',
-  'require.resolve',
-  'System.import',
+const defaultTransformFunctions = [
+  { pattern: 'require', isModulePath: true },
+  { pattern: 'require.resolve', isModulePath: true },
+  { pattern: 'System.import', isModulePath: true },
 
   // Jest methods
-  'jest.genMockFromModule',
-  'jest.mock',
-  'jest.unmock',
-  'jest.doMock',
-  'jest.dontMock',
-  'jest.setMock',
-  'require.requireActual',
-  'require.requireMock',
+  { pattern: 'jest.genMockFromModule', isModulePath: true },
+  { pattern: 'jest.mock', isModulePath: true },
+  { pattern: 'jest.unmock', isModulePath: true },
+  { pattern: 'jest.doMock', isModulePath: true },
+  { pattern: 'jest.dontMock', isModulePath: true },
+  { pattern: 'jest.setMock', isModulePath: true },
+  { pattern: 'require.requireActual', isModulePath: true },
+  { pattern: 'require.requireMock', isModulePath: true },
 ];
 
 function isRegExp(string) {
@@ -122,12 +122,30 @@ function normalizeAlias(optsAlias) {
   }, []);
 }
 
-function normalizeTransformedFunctions(optsTransformFunctions) {
-  if (!optsTransformFunctions) {
-    return defaultTransformedFunctions;
+function normalizeTransformFunctionsElement(optsTransformFunction) {
+  let pattern;
+  let opts;
+  if (Array.isArray(optsTransformFunction)) {
+    [pattern, opts] = optsTransformFunction;
+  } else {
+    [pattern, opts] = [optsTransformFunction, {}];
   }
 
-  return [...defaultTransformedFunctions, ...optsTransformFunctions];
+  const finalOpts = { pattern, isModulePath: true };
+  if ('isModulePath' in opts) {
+    finalOpts.isModulePath = opts.isModulePath;
+  }
+
+  return finalOpts;
+}
+
+function normalizeTransformFunctions(optsTransformFunctions) {
+  if (!optsTransformFunctions) {
+    return defaultTransformFunctions;
+  }
+
+  return [...defaultTransformFunctions,
+    ...optsTransformFunctions.map(normalizeTransformFunctionsElement)];
 }
 
 function normalizeLoglevel(optsLoglevel) {
@@ -143,7 +161,7 @@ export default createSelector(
     const root = normalizeRoot(opts.root, cwd);
     const alias = normalizeAlias(opts.alias);
     const loglevel = normalizeLoglevel(opts.loglevel);
-    const transformFunctions = normalizeTransformedFunctions(opts.transformFunctions);
+    const transformFunctions = normalizeTransformFunctions(opts.transformFunctions);
     const extensions = opts.extensions || defaultExtensions;
     const stripExtensions = opts.stripExtensions || extensions;
 

--- a/src/transformers/call.js
+++ b/src/transformers/call.js
@@ -7,12 +7,16 @@ export default function transformCall(nodePath, state) {
   }
 
   const calleePath = nodePath.get('callee');
-  const isNormalCall = state.normalizedOpts.transformFunctions.some(pattern =>
+  const transformFunction = state.normalizedOpts.transformFunctions.find(({ pattern }) =>
     matchesPattern(state.types, calleePath, pattern)
   );
 
-  if (isNormalCall || isImportCall(state.types, nodePath)) {
+  if (transformFunction) {
     state.moduleResolverVisited.add(nodePath);
-    mapPathString(nodePath.get('arguments.0'), state);
+    const { isModulePath } = transformFunction;
+    mapPathString(nodePath.get('arguments.0'), state, { isModulePath });
+  } else if (isImportCall(state.types, nodePath)) {
+    state.moduleResolverVisited.add(nodePath);
+    mapPathString(nodePath.get('arguments.0'), state, { isModulePath: true });
   }
 }

--- a/src/transformers/import.js
+++ b/src/transformers/import.js
@@ -6,5 +6,5 @@ export default function transformImport(nodePath, state) {
   }
   state.moduleResolverVisited.add(nodePath);
 
-  mapPathString(nodePath.get('source'), state);
+  mapPathString(nodePath.get('source'), state, { isModulePath: true });
 }

--- a/test/custom-call.test.js
+++ b/test/custom-call.test.js
@@ -3,7 +3,8 @@ import plugin from '../src';
 
 
 const calls = [
-  'customMethod.something',
+  'customMethod.Module',
+  'customMethod.NonModule',
 ];
 
 describe('custom calls', () => {
@@ -16,7 +17,8 @@ describe('custom calls', () => {
           test: './test/testproject/test',
         },
         transformFunctions: [
-          'customMethod.something',
+          'customMethod.Module',
+          ['customMethod.NonModule', { isModulePath: false }],
         ],
       }],
     ],
@@ -59,13 +61,6 @@ describe('custom calls', () => {
         expect(result.code).toBe(`${name}(path, ...args);`);
       });
 
-      it('should handle an empty path', () => {
-        const code = `${name}('', ...args);`;
-        const result = transform(code, transformerOpts);
-
-        expect(result.code).toBe(`${name}('', ...args);`);
-      });
-
       it('should ignore the call if the method name is not fully matched (suffix)', () => {
         const code = `${name}.after("components/Sidebar/Footer", ...args);`;
         const result = transform(code, transformerOpts);
@@ -79,6 +74,26 @@ describe('custom calls', () => {
 
         expect(result.code).toBe(`before.${name}("components/Sidebar/Footer", ...args);`);
       });
+    });
+  });
+
+  describe('customMethod.Module', () => {
+    const name = 'customMethod.Module';
+    it('should handle an empty path', () => {
+      const code = `${name}('', ...args);`;
+      const result = transform(code, transformerOpts);
+
+      expect(result.code).toBe(`${name}('', ...args);`);
+    });
+  });
+
+  describe('customMethod.NonModule', () => {
+    const name = 'customMethod.NonModule';
+    it('should handle an empty path', () => {
+      const code = `${name}('', ...args);`;
+      const result = transform(code, transformerOpts);
+
+      expect(result.code).toBe(`${name}("./test/testproject/src", ...args);`);
     });
   });
 });


### PR DESCRIPTION
This will allow resolving paths that aren't necessarily pointing to modules.
E.g. views or static directory for express.js.

This can be achieved by adding isModulePath options to transform function. It makes sense to add this option there because whether the path should be interpreted as a path to the module or not depends on the calling function.

My use case is for configuring views and static directory for express.js. With this PR I can do something like this:
```js
app.use(express.static(resolvePath('$res/public/')));
```
Where resolvePath is just an identity function (see [DOCS.md#usage-with-proxyquire](https://github.com/tleunen/babel-plugin-module-resolver/blob/d4a596cab6429e2d100cf7ef6078fd43aec62b41/DOCS.md#usage-with-proxyquire)) and is configured via `transformFunctions` options like this:
```js
transformFunctions: [
  ['resolvePath', { isModulePath: false }],
],
```