### PR TITLE
Add new jest methods

### DIFF
--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -21,6 +21,10 @@ const defaultTransformedFunctions = [
   'jest.doMock',
   'jest.dontMock',
   'jest.setMock',
+  'jest.requireActual',
+  'jest.requireMock',
+
+  // Older Jest methods
   'require.requireActual',
   'require.requireMock',
 ];

--- a/test/call.test.js
+++ b/test/call.test.js
@@ -1,7 +1,6 @@
 import { transform } from '@babel/core';
 import plugin from '../src';
 
-
 // all calls take a path as the first argument
 const calls = [
   'require',
@@ -13,6 +12,8 @@ const calls = [
   'jest.doMock',
   'jest.dontMock',
   'jest.setMock',
+  'jest.requireActual',
+  'jest.requireMock',
   'require.requireActual',
   'require.requireMock',
 ];
@@ -21,22 +22,27 @@ describe('function and method calls', () => {
   const transformerOpts = {
     babelrc: false,
     plugins: [
-      [plugin, {
-        root: './test/testproject/src',
-        alias: {
-          test: './test/testproject/test',
+      [
+        plugin,
+        {
+          root: './test/testproject/src',
+          alias: {
+            test: './test/testproject/test',
+          },
         },
-      }],
+      ],
     ],
   };
 
-  calls.forEach((name) => {
+  calls.forEach(name => {
     describe(name, () => {
       it('should resolve the path based on the root config', () => {
         const code = `${name}("components/Header/SubHeader", ...args);`;
         const result = transform(code, transformerOpts);
 
-        expect(result.code).toBe(`${name}("./test/testproject/src/components/Header/SubHeader", ...args);`);
+        expect(result.code).toBe(
+          `${name}("./test/testproject/src/components/Header/SubHeader", ...args);`
+        );
       });
 
       it('should alias the path', () => {
@@ -94,7 +100,9 @@ describe('function and method calls', () => {
     const code = 'require["resolve"]("components/Sidebar/Footer", ...args);';
     const result = transform(code, transformerOpts);
 
-    expect(result.code).toBe('require["resolve"]("./test/testproject/src/components/Sidebar/Footer", ...args);');
+    expect(result.code).toBe(
+      'require["resolve"]("./test/testproject/src/components/Sidebar/Footer", ...args);'
+    );
   });
 
   it('should ignore the call if the method name is unknown', () => {


### PR DESCRIPTION
Newer versions of jest use `jest.requireActual` and `jest.requireMock` instead of `require.requireActual` and `require.requireMock`