### PR TITLE
Valid install commands when using Github copy button

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -18,7 +18,11 @@
 Install the plugin
 
 ```
-$ npm install --save-dev babel-plugin-module-resolver
+npm install --save-dev babel-plugin-module-resolver
+```
+or
+```
+yarn add --dev babel-plugin-module-resolver
 ```
 
 Specify the plugin in your `.babelrc` with the custom root or alias. Here's an example:

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ const MyUtilFn = require('../../../../utils/MyUtilFn');
 Install the plugin
 
 ```
-$ npm install --save-dev babel-plugin-module-resolver
+npm install --save-dev babel-plugin-module-resolver
 ```
 or
 ```
-$ yarn add --dev babel-plugin-module-resolver
+yarn add --dev babel-plugin-module-resolver
 ```
 
 Specify the plugin in your `.babelrc` with the custom root or alias. Here's an example:


### PR DESCRIPTION
As it is if you click on the GitHub markdown copy button on the right you have to then manually remove the $.

<img width="866" alt="Screenshot 2021-07-26 at 14 06 54" src="https://user-images.githubusercontent.com/1764217/126986735-2bc7da10-572e-4266-a829-3a4bc03c99c0.png">
