### PR TITLE
allow for optional relative resolve for non-standard extensions

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -271,6 +271,49 @@ describe('module-resolver', () => {
       });
     });
 
+    describe('non-standard relative double extension', () => {
+      const rootTransformerOpts = {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            resolveRelativePaths: true,
+            root: './test/testproject/src',
+            extensions: ['.ios.js', '.android.js', '.js'],
+          }],
+        ],
+      };
+
+      it('should not resolve the file path with an unknown extension', () => {
+        testWithImport(
+          './rn',
+          './test/testproject/src/rn',
+          rootTransformerOpts,
+        );
+      });
+    });
+
+    describe('non-standard relative double extension without extension stripping', () => {
+      const rootTransformerOpts = {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            resolveRelativePaths: true,
+            root: './test/testproject/src',
+            extensions: ['.ios.js', '.android.js', '.js'],
+            stripExtensions: [],
+          }],
+        ],
+      };
+
+      it('should not resolve the file path with an unknown extension', () => {
+        testWithImport(
+          './rn',
+          './test/testproject/src/rn/index.ios.js',
+          rootTransformerOpts,
+        );
+      });
+    });
+
     describe('non-standard double extensions with strip extensions', () => {
       const rootTransformerOpts = {
         babelrc: false,


### PR DESCRIPTION
This looks to resolve https://github.com/tleunen/babel-plugin-module-resolver/issues/201 which is a continuation of a couple open PRs: https://github.com/tleunen/babel-plugin-module-resolver/pull/259 and https://github.com/tleunen/babel-plugin-module-resolver/pull/317.

The feedback I see in those PRs seems to be that this is for a "non-standard" use case and the effect of putting relative path resolution in the "standard path" could be detrimental to the vast majority of use cases.

For this PR I've opted to make the relative resolution strategy an opt-in. Therefore, if you were looking to replicate the react-native extension behaviour, you'd have the following config:

```js
{
  extensions: ['.ios.js', '.android.js', '.js'],
  stripExtensions: [],
}
```

or some variation. I'd note that this behaviour is becoming standard with the `.web.js` and `.native.js` extensions that are proliferating in react-land. I needed this for `react-redux` for example, which [uses this to select the right batch method](https://github.com/reduxjs/react-redux/blob/d4e4eba9ccbd488b103b3c5625a37e15b1427d11/src/index.ts#L7).