### PR TITLE
fix(tests): run all tests

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,7 +42,7 @@ describe('module-resolver', () => {
         ],
       };
 
-      it.only('should resolve the file path', () => {
+      it('should resolve the file path', () => {
         testWithImport('app', './test/testproject/src/app', rootTransformerOpts);
       });
 


### PR DESCRIPTION
Some tests are skipped, this change allows to launch all the tests by removing the `only` keyword