### PR TITLE
feat(alias): added currentFile as second parameter to alias functions

### DIFF
--- a/src/resolvePath.js
+++ b/src/resolvePath.js
@@ -63,7 +63,7 @@ function resolvePathFromAliasConfig(sourcePath, currentFile, opts) {
       return false;
     }
 
-    aliasedSourceFile = substitute(execResult);
+    aliasedSourceFile = substitute(execResult, currentFile);
     return true;
   });
 


### PR DESCRIPTION
This is small change that allows to make alias functions more flexible. For example, it helps you to create lib wrappers locally without npm libs creating 